### PR TITLE
Allow the test runner to work with ASAN builds

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -31,9 +31,4 @@ else
     make
 fi
 
-if [[ ${BUILD_TYPE} == "ASAN" ]]
-then
-    LD_PRELOAD=libasan.so ./test_runner
-else
-    ./test_runner
-fi
+./test_runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 env:
   - GEN="Unix Makefiles" BUILD_TYPE=Release
   - GEN="Unix Makefiles" BUILD_TYPE=Debug
+  - GEN="Unix Makefiles" BUILD_TYPE=ASAN
 addons:
   apt:
     packages:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,17 +111,24 @@ file(GLOB EXE_SRCS ${EXE_DIR}/*.c)
 
 # CFLAGS
 
-set(DEFAULT_DEBUG "-std=c11 -g -ggdb -O0")
+set(DEFAULT_DEBUG "-g -ggdb -O0")
 set(DEV_WARNINGS "-Wall -Werror -Wshadow -Wstrict-overflow -fno-strict-aliasing")
 set(CMAKE_C_FLAGS_DEBUG
-    "${CMAKE_C_FLAGS_DEBUG} ${DEFAULT_DEBUG} ${DEV_WARNINGS}")
+    "${CMAKE_C_FLAGS_DEBUG} -std=c11 ${DEFAULT_DEBUG} ${DEV_WARNINGS}")
+set(CMAKE_CXX_FLAGS_DEBUG
+    "${CMAKE_CXX_FLAGS_DEBUG} -std=c++11 ${DEFAULT_DEBUG} ${DEV_WARNINGS}")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -std=c11 -O2 -Wall")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=c++11 -O2 -Wall")
 
 # Add custom build type
 
 # Add new build types
 set(CMAKE_C_FLAGS_ASAN
-    "${DEFAULT_DEBUG} ${DEV_WARNINGS} -fsanitize=address -fno-omit-frame-pointer"
+    "${DEFAULT_DEBUG} ${DEV_WARNINGS} -std=c11 -fsanitize=address -fno-omit-frame-pointer"
+    CACHE STRING "Flags used by the C compiler during address sanitizer builds."
+    FORCE )
+set(CMAKE_CXX_FLAGS_ASAN
+    "${DEFAULT_DEBUG} ${DEV_WARNINGS} -std=c++11 -fsanitize=address -fno-omit-frame-pointer"
     CACHE STRING "Flags used by the C++ compiler during address sanitizer builds."
     FORCE )
 set(CMAKE_EXE_LINKER_FLAGS_ASAN

--- a/tests/test_buffer.cpp
+++ b/tests/test_buffer.cpp
@@ -7,7 +7,7 @@ extern "C" {
 static char eight_nulls[] = "\x00\x00\x00\x00\x00\x00\x00\x00";
 
 TEST(buffer, zero_size_init) {
-    int i;
+    size_t i;
     int res = 0;
     struct sylkie_buffer* buf = sylkie_buffer_init(0);
 


### PR DESCRIPTION
When compiling the test runner ensure that -fsanitize=address is used.