### PR TITLE
Add better parsing

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -31,4 +31,4 @@ else
     make
 fi
 
-./test_runner
+./sylkie_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,15 +239,15 @@ if(ENABLE_TESTS)
 
     file(GLOB TEST_SRCS ${TEST_DIR}/test_*.cpp)
 
-    add_executable(test_runner ${TEST_DIR}/runner.cpp ${TEST_SRCS} ${EXE_SRCS}
+    add_executable(${PROJECT_NAME}_test ${TEST_DIR}/runner.cpp ${TEST_SRCS} ${EXE_SRCS}
         ${LIB_SRCS})
-    set_target_properties(test_runner PROPERTIES LINKER_LANGUAGE CXX)
-    target_include_directories(test_runner PRIVATE ${EXE_DIR}/include)
+    set_target_properties(${PROJECT_NAME}_test PROPERTIES LINKER_LANGUAGE CXX)
+    target_include_directories(${PROJECT_NAME}_test PRIVATE ${EXE_DIR}/include)
     if (JSON)
-        target_link_libraries(test_runner json-c)
+        target_link_libraries(${PROJECT_NAME}_test json-c)
     endif(JSON)
     if(SECCOMP)
-        target_link_libraries(test_runner seccomp)
+        target_link_libraries(${PROJECT_NAME}_test seccomp)
     endif(SECCOMP)
 
     if(GTEST_FOUND)
@@ -260,11 +260,11 @@ if(ENABLE_TESTS)
                      "${CMAKE_BINARY_DIR}/libgtest.so")
     endif(GTEST_FOUND)
 
-    target_link_libraries(test_runner gtest)
+    target_link_libraries(${PROJECT_NAME}_test gtest)
 
     foreach(test ${TEST_SRCS})
         get_filename_component(TEST_NAME ${test} NAME_WE)
-        add_test(test_runner test_runner ${TEST_NAME})
+        add_test(${PROJECT_NAME}_test ${PROJECT_NAME}_test ${TEST_NAME})
     endforeach(test)
 
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ file(GLOB INCLUDE_FILES ${INCLUDE_DIR}/*.h)
 file(GLOB LIB_SRCS ${LIB_DIR}/*.c)
 
 file(GLOB EXE_SRCS ${EXE_DIR}/*.c)
+list(REMOVE_ITEM EXE_SRCS "${EXE_DIR}/main.c")
 
 # CFLAGS
 
@@ -149,11 +150,6 @@ mark_as_advanced(
 
 # Outputs
 
-add_executable(${PROJECT_NAME}-bin ${EXE_SRCS} ${LIB_SRCS})
-set_target_properties(${PROJECT_NAME}-bin PROPERTIES
-    OUTPUT_NAME ${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME}-bin PRIVATE ${EXE_DIR}/include)
-
 add_library(${PROJECT_NAME}-shared SHARED ${LIB_SRCS})
 set_target_properties(${PROJECT_NAME}-shared PROPERTIES
     OUTPUT_NAME ${PROJECT_NAME})
@@ -163,6 +159,12 @@ set_target_properties(${PROJECT_NAME}-shared PROPERTIES
 add_library(${PROJECT_NAME}-static STATIC ${LIB_SRCS})
 set_target_properties(${PROJECT_NAME}-static PROPERTIES
     OUTPUT_NAME ${PROJECT_NAME})
+
+add_executable(${PROJECT_NAME}-bin ${EXE_SRCS} ${EXE_DIR}/main.c)
+set_target_properties(${PROJECT_NAME}-bin PROPERTIES
+    OUTPUT_NAME ${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME}-bin PRIVATE ${EXE_DIR}/include)
+target_link_libraries(${PROJECT_NAME}-bin PRIVATE ${PROJECT_NAME}-shared)
 
 # Dependencies
 
@@ -237,9 +239,16 @@ if(ENABLE_TESTS)
 
     file(GLOB TEST_SRCS ${TEST_DIR}/test_*.cpp)
 
-    add_executable(test_runner ${TEST_DIR}/runner.cpp ${TEST_SRCS})
+    add_executable(test_runner ${TEST_DIR}/runner.cpp ${TEST_SRCS} ${EXE_SRCS}
+        ${LIB_SRCS})
     set_target_properties(test_runner PROPERTIES LINKER_LANGUAGE CXX)
-    target_link_libraries(test_runner ${PROJECT_NAME}-shared)
+    target_include_directories(test_runner PRIVATE ${EXE_DIR}/include)
+    if (JSON)
+        target_link_libraries(test_runner json-c)
+    endif(JSON)
+    if(SECCOMP)
+        target_link_libraries(test_runner seccomp)
+    endif(SECCOMP)
 
     if(GTEST_FOUND)
         include_directories(${GTEST_INCLUDE_DIRS})

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -1,0 +1,748 @@
+// Copyright (c) 2017 Daniel L. Robertson
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <strings.h>
+#include <string.h>
+
+#include <netinet/ether.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <cfg.h>
+#include <utils.h>
+
+
+// Integer parsers
+
+static struct cfg_set_item* parse_int_cmdline(const struct cfg_parser* parser, const char* arg) {
+    int value = strtol(arg, NULL, 10);
+    if (value < 0) {
+        if (strcmp(arg, "-1") == 0) {
+            value = -1;
+        } else {
+            return NULL;
+        }
+    }
+    return cfg_set_item_create(parser, &value);
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_int_json(const struct cfg_parser* parser, struct json_object* jobj) {
+    int value = 0;
+    enum json_type type = json_object_get_type(jobj);
+    if (type == json_type_int) {
+        value = json_object_get_int(jobj);
+        return cfg_set_item_create(parser, &value);
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+// Word parsers
+
+static struct cfg_set_item* parse_word_cmdline(const struct cfg_parser* parser, const char* arg) {
+    int value = strtol(arg, NULL, 10);
+    if (value > 0xffff || value < 0) {
+        return NULL;
+    } else {
+        return cfg_set_item_create(parser, &value);
+    }
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_word_json(const struct cfg_parser* parser, struct json_object* jobj) {
+    int value = 0;
+    enum json_type type = json_object_get_type(jobj);
+    if (type == json_type_int) {
+        value = json_object_get_int(jobj);
+        if (value > 0xffff || value < 0) {
+            return NULL;
+        } else {
+            return cfg_set_item_create(parser, &value);
+        }
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+// Byte parsers
+
+static struct cfg_set_item* parse_byte_cmdline(const struct cfg_parser* parser, const char* arg) {
+    int value = strtol(arg, NULL, 10);
+    if (value > 0xff || value < 0) {
+        return NULL;
+    } else {
+        return cfg_set_item_create(parser, &value);
+    }
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_byte_json(const struct cfg_parser* parser, struct json_object* jobj) {
+    int value = 0;
+    enum json_type type = json_object_get_type(jobj);
+    if (type == json_type_int) {
+        value = json_object_get_int(jobj);
+        if (value > 0xff || value < 0) {
+            return NULL;
+        } else {
+            return cfg_set_item_create(parser, &value);
+        }
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+// String parsers
+
+static char* copy_str(const char* arg) {
+    int len;
+    char* value;
+    if (!arg || (len = strlen(arg)) <= 0) {
+        value = malloc(1);
+        if (value) {
+            value[0] = '\0';
+            return value;
+        } else {
+            return NULL;
+        }
+    } else {
+        value = malloc(len + 1);
+        if (value) {
+            strncpy(value, arg, len);
+            value[len] = '\0';
+            return value;
+        } else {
+            return NULL;
+        }
+    }
+}
+
+static struct cfg_set_item* parse_string_cmdline(const struct cfg_parser* parser, const char* arg) {
+    char* value = copy_str(arg);
+    struct cfg_set_item* item = NULL;
+    if (value) {
+        // TODO(dlrobertson): linters complain about using cfg_set_item_create here.
+        // Figure out why that is the case. There is probably a bug here
+        item = malloc(sizeof(struct cfg_set_item));
+        item->value.type = parser->type;
+        item->name = parser->long_name;
+        item->value.data = value;
+        return item;
+    } else {
+        return NULL;
+    }
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_string_json(const struct cfg_parser* parser,
+                                              struct json_object* jobj) {
+    char* value = NULL;
+    struct cfg_set_item* item = NULL;
+    enum json_type type = json_object_get_type(jobj);
+    if (type == json_type_string) {
+        value = copy_str(json_object_get_string(jobj));
+        if (value) {
+            // TODO(dlrobertson): linters complain about using cfg_set_item_create here.
+            // Figure out why that is the case. There is probably a bug here
+            item = malloc(sizeof(struct cfg_set_item));
+            item->value.type = parser->type;
+            item->name = parser->long_name;
+            item->value.data = value;
+            return item;
+        } else {
+            return NULL;
+        }
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+// IPv6 address parsers
+
+static struct cfg_set_item* parse_ipv6_addr_cmdline(const struct cfg_parser* parser,
+                                                    const char* arg) {
+    int res = 0;
+    struct in6_addr* value = malloc(sizeof(struct in6_addr));
+
+    if (!value) {
+        return NULL;
+    }
+
+    res = inet_pton(AF_INET6, arg, value);
+    if (res <= 0) {
+        return NULL;
+    } else {
+        return cfg_set_item_create(parser, value);
+    }
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_ipv6_addr_json(const struct cfg_parser* parser,
+                                                 struct json_object* jobj) {
+    int res = 0;
+    const char* tmp = NULL;
+    struct in6_addr* value = malloc(sizeof(struct in6_addr));
+    enum json_type type = json_object_get_type(jobj);
+
+    if (!value) {
+        return NULL;
+    }
+
+    if (type == json_type_string) {
+        tmp = json_object_get_string(jobj);
+        res = inet_pton(AF_INET6, tmp, value);
+        if (res <= 0) {
+            free(value);
+            return NULL;
+        } else {
+            return cfg_set_item_create(parser, value);
+        }
+    } else {
+        free(value);
+        return NULL;
+    }
+}
+#endif
+
+// Mac parsers
+
+static struct cfg_set_item* parse_mac_cmdline(const struct cfg_parser* parser, const char* arg) {
+    int res = 0;
+    u_int8_t* value = malloc(ETH_ALEN);
+
+    if (!value) {
+        return NULL;
+    }
+
+    res = parse_hwaddr(arg, value);
+    if (res < 0) {
+        free(value);
+        return NULL;
+    } else {
+        return cfg_set_item_create(parser, value);
+    }
+}
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_mac_json(const struct cfg_parser* parser, struct json_object* jobj) {
+    int res = 0;
+    u_int8_t* value = malloc(ETH_ALEN);
+    const char* tmp = NULL;
+    enum json_type type = json_object_get_type(jobj);
+
+    if (!value) {
+        return NULL;
+    }
+
+    if (type == json_type_string) {
+        tmp = json_object_get_string(jobj);
+        res = parse_hwaddr(tmp, value);
+        if (res < 0) {
+            free(value);
+            return NULL;
+        } else {
+            return cfg_set_item_create(parser, value);
+        }
+    } else {
+        free(value);
+        return NULL;
+    }
+}
+#endif
+
+// Boolean parsers
+//
+// Note: The command line version does not need a parser. The value is assumed by the presence
+// of the option.
+
+#ifdef BUILD_JSON
+static struct cfg_set_item* parse_bool_json(const struct cfg_parser* parser, struct json_object* jobj) {
+    bool value;
+    enum json_type type = json_object_get_type(jobj);
+    if (type == json_type_boolean) {
+        value = json_object_get_boolean(jobj);
+        return cfg_set_item_create(parser, &value);
+    } else {
+        return NULL;
+    }
+}
+#endif
+
+// Helper function used to choose the correct parsing function based on the argument type
+// for command line input
+static struct cfg_set_item* parse_cmdline_arg(const struct cfg_parser* parser, const char* arg) {
+    switch (parser->type) {
+    case CFG_INT:
+        return parse_int_cmdline(parser, arg);
+    case CFG_WORD:
+        return parse_word_cmdline(parser, arg);
+    case CFG_BYTE:
+        return parse_byte_cmdline(parser, arg);
+    case CFG_STRING:
+        return parse_string_cmdline(parser, arg);
+    case CFG_IPV6_ADDRESS:
+        return parse_ipv6_addr_cmdline(parser, arg);
+    case CFG_HW_ADDRESS:
+        return parse_mac_cmdline(parser, arg);
+    default:
+        return NULL;
+    }
+}
+
+#ifdef BUILD_JSON
+// Helper function used to choose the correct parsing function based on the argument type
+// for json input
+static struct cfg_set_item* parse_json_arg(const struct cfg_parser* parser, struct json_object* jobj) {
+    switch (parser->type) {
+    case CFG_INT:
+        return parse_int_json(parser, jobj);
+    case CFG_WORD:
+        return parse_word_json(parser, jobj);
+    case CFG_BYTE:
+        return parse_byte_json(parser, jobj);
+    case CFG_STRING:
+        return parse_string_json(parser, jobj);
+    case CFG_IPV6_ADDRESS:
+        return parse_ipv6_addr_json(parser, jobj);
+    case CFG_HW_ADDRESS:
+        return parse_mac_json(parser, jobj);
+    case CFG_BOOL:
+        return parse_bool_json(parser, jobj);
+    default:
+        return NULL;
+    }
+}
+#endif
+
+// Generic function used to create a set item
+struct cfg_set_item* cfg_set_item_create(const struct cfg_parser* parser, void* data) {
+    struct cfg_set_item* item = malloc(sizeof(struct cfg_set_item));
+    if (item) {
+        item->value.type = parser->type;
+        item->name = parser->long_name;
+        switch (item->value.type) {
+        case CFG_STRING:
+        case CFG_IPV6_ADDRESS:
+        case CFG_HW_ADDRESS:
+            item->value.data = data;
+            break;
+        case CFG_INT:
+            item->value.integer = *(int*)data;
+            break;
+        case CFG_WORD:
+            item->value.word = *(u_int16_t*)data;
+            break;
+        case CFG_BYTE:
+            item->value.byte = *(u_int8_t*)data;
+            break;
+        case CFG_BOOL:
+            item->value.boolean = *(bool*)data;
+            break;
+        default:
+            free(item);
+            return NULL;
+        }
+    }
+    return item;
+}
+
+void cfg_set_item_free(struct cfg_set_item* item) {
+    if (item) {
+        if (item->value.type & (CFG_STRING | CFG_IPV6_ADDRESS | CFG_HW_ADDRESS)) {
+            free(item->value.data);
+            item->value.data = NULL;
+        }
+        free(item);
+        item = NULL;
+    }
+}
+
+// Helper function used by qsort to sort the btree of cfg_set_items
+static int cfg_set_cmp(const void* elem1, const void* elem2) {
+    const struct cfg_set_item* item1 = *(const struct cfg_set_item**)elem1;
+    const struct cfg_set_item* item2 = *(const struct cfg_set_item**)elem2;
+    return strcmp(item2->name, item1->name);
+}
+
+// Find the correct parser for input given the short hand version
+static const struct cfg_parser* find_parser_char(const char arg, size_t sz,
+                                                 const struct cfg_parser* parsers) {
+    const struct cfg_parser* iter;
+    const struct cfg_parser* end = parsers + sz;
+    for (iter = parsers; iter < end; ++iter) {
+        if (arg == iter->short_name) {
+            return iter;
+        }
+    }
+    return NULL;
+}
+
+// Find the correct parser for input given the long hand version
+static const struct cfg_parser* find_parser_str(const char* arg, size_t len, size_t sz,
+                                                const struct cfg_parser* parsers) {
+    const struct cfg_parser* iter;
+    const struct cfg_parser* end = parsers + sz;
+    if (!len) {
+        len = strlen(arg);
+    }
+    for (iter = parsers; iter < end; ++iter) {
+        if (strncmp(arg, iter->long_name, len) == 0) {
+            return iter;
+        }
+    }
+    return NULL;
+}
+
+int cfg_set_add(struct cfg_map* set, struct cfg_set_item* item) {
+    struct cfg_set_item** tmp;
+    if (set->len + 1 > set->cap) {
+        tmp = malloc(sizeof(struct cfg_set_item*) * (set->cap + 10));
+        if (tmp) {
+            memcpy(tmp, set->map, set->len * sizeof(struct cfg_set_item*));
+            free(set->map);
+            set->map = tmp;
+            set->cap += 10;
+        } else {
+            return -1;
+        }
+    }
+    set->map[set->len] = item;
+    ++set->len;
+    return 0;
+}
+
+// Helper function used to parse longhand arguments. This is a bit more complicated than it
+// needs to be, due to the initial implementation of sylkie. The initial implementation did
+// not require that argments to longhang options be of the form --option=argument, but
+// instead --option argument. As a result, we also need to pass the next string in argv to
+// this function
+static int cfg_set_parse_long(struct cfg_map* map, const struct cfg_parser* parsers,
+                               size_t sz, const char* arg, const char* next,
+                               bool *next_consumed) {
+    char* iter = NULL;
+    const struct cfg_parser* parser = NULL;
+    struct cfg_set_item* item = NULL;
+    static bool true_value = true;
+    bool used_equals = false;
+    int len = 0;
+    if ((iter = strchr(arg, '=')) != NULL) {
+        len = iter - arg;
+        next = iter + 1;
+        used_equals = true;
+    }
+    if ((parser = find_parser_str(arg, len, sz, parsers))) {
+        // We don't need to parse an argument for boolean options
+        if (parser->type != CFG_BOOL) {
+            if (next) {
+                item = parse_cmdline_arg(parser, next);
+                if (item) {
+                    if (cfg_set_add(map, item)) {
+                        fprintf(stderr, "ERROR: No memory\n");
+                        free(item);
+                        return -1;
+                    }
+                } else {
+                    fprintf(stderr, "ERROR: %s invalid argument for %s\n",
+                            next, parser->long_name);
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "ERROR: --%s requires an argument\n", arg);
+                return -1;
+            }
+            if (!used_equals) {
+                *next_consumed = true;
+            }
+        } else {
+            item = cfg_set_item_create(parser, &true_value);
+            if (item) {
+                if (cfg_set_add(map, item)) {
+                    fprintf(stderr, "ERROR: No memory\n");
+                    free(item);
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "ERROR: Could not create value for %s\n", arg);
+                return -1;
+            }
+        }
+    } else {
+        fprintf(stderr, "Unknown argument: %s\n", arg);
+        return -1;
+    }
+
+    return 0;
+}
+
+// Helper function used to parse shorthand arguments. This is a bit more complicated, as
+// combinations (e.g -vh, -ip) should be expected. -vh would be a legal combination, as
+// neither of them requires an argument. However -ip would be invalid, as both of them require
+// an argument and it is therefore unclear who owns the given argument.
+static int cfg_set_parse_short(struct cfg_map* map, const struct cfg_parser* parsers,
+                               size_t sz, const char* arg, size_t len,
+                               const char* next, bool* next_consumed) {
+    int i;
+    const struct cfg_parser* parser = NULL;
+    struct cfg_set_item* item = NULL;
+    static bool true_value = true;
+    // Flag value indicating the argument has been consumed by one of the options
+    for (i = 0; i < len; ++i) {
+        if ((parser = find_parser_char(arg[i], sz, parsers))) {
+            // We don't need to parse an argument for boolean options
+            if (parser->type != CFG_BOOL) {
+                if (*next_consumed) {
+                    fprintf(stderr,
+                            "ERROR: Invalid combination \"-%s\". -%c"
+                            "requires an argument\n",
+                            arg, arg[i]);
+                    return -1;
+                } else if (!next) {
+                    fprintf(stderr, "ERROR: -%c requires an argument\n", arg[i]);
+                    return -1;
+                }
+                *next_consumed = true;
+                item = parse_cmdline_arg(parser, next);
+                if (item) {
+                    if (cfg_set_add(map, item)) {
+                        free(item);
+                        fprintf(stderr, "ERROR: No memory\n");
+                        return -1;
+                    }
+                } else {
+                    fprintf(stderr, "ERROR: %s invalid argument for %s\n",
+                            next, parser->long_name);
+                    return -1;
+                }
+            } else {
+                item = cfg_set_item_create(parser, &true_value);
+                if (item) {
+                    if (cfg_set_add(map, item)) {
+                        free(item);
+                        fprintf(stderr, "ERROR: No memory\n");
+                        return -1;
+                    }
+                } else {
+                    fprintf(stderr, "ERROR: %s invalid argument for %s\n",
+                            next, parser->long_name);
+                    return -1;
+                }
+            }
+            item = NULL;
+        }
+    }
+    return 0;
+}
+
+
+// Initialize a cfg_set for json parsing
+#ifdef BUILD_JSON
+int cfg_set_init_json(struct cfg_set* set, struct json_object* jobj) {
+    const struct cfg_parser* parser = NULL;
+    struct cfg_set_item* item = NULL;
+    set->options.map = malloc(sizeof(struct cfg_set_item*) * 5);
+    if (!set->options.map) {
+        return -1;
+    }
+    set->options.len = 0;
+    set->options.cap = 5;
+    bzero(set->options.map, 5);
+    json_object_object_foreach(jobj, key, val) {
+        if ((parser = find_parser_str(key, 0, set->parsers_sz, set->parsers))) {
+            item = parse_json_arg(parser, val);
+            if (item) {
+                cfg_set_add(&set->options, item);
+            } else {
+                fprintf(stderr, "ERROR: %s invalid argument for %s\n",
+                        json_object_to_json_string(val), parser->long_name);
+                return -1;
+            }
+        }
+    }
+    qsort(set->options.map, set->options.len, sizeof(struct cfg_set_item*), cfg_set_cmp);
+    return 0;
+}
+#endif
+
+// Initialize a cfg_set for command line parsing
+int cfg_set_init_cmdline(struct cfg_set* set, size_t argc, const char** argv) {
+    bool next_consumed = false;
+    const char** iter = argv;
+    const char** end = argv + argc;
+    const char* arg;
+    size_t len = (argc) ? (argc / 2) : 1;
+    set->options.map = malloc(sizeof(struct cfg_set_item*) * len);
+    if (!set->options.map) {
+        return -1;
+    }
+    set->options.len = 0;
+    set->options.cap = len;
+    bzero(set->options.map, len);
+    while (iter < end) {
+        arg = *iter;
+        len = strlen(arg);
+        if (len > 1 && arg[0] == '-') {
+            if (arg[1] != '-') {
+                ++iter;
+                if (cfg_set_parse_short(&set->options, set->parsers, set->parsers_sz,
+                                        ++arg, --len, *iter, &next_consumed)) {
+                    cfg_set_free(set);
+                    return -1;
+                }
+            } else if (len > 2) {
+                ++iter;
+                arg += 2;
+                if (cfg_set_parse_long(&set->options, set->parsers, set->parsers_sz,
+                                       arg, *iter, &next_consumed)) {
+                    cfg_set_free(set);
+                    return -1;
+                }
+            } else {
+                fprintf(stderr, "Unknown argument: %s\n", arg);
+                cfg_set_free(set);
+                return -1;
+            }
+        } else {
+            fprintf(stderr, "Unknown argument: %s\n", arg);
+            cfg_set_free(set);
+            return -1;
+        }
+        if (next_consumed) {
+            ++iter;
+            next_consumed = false;
+        }
+    }
+    qsort(set->options.map, set->options.len, sizeof(struct cfg_set_item*), cfg_set_cmp);
+    return 0;
+}
+
+static const struct cfg_set_item* cfg_set_find_inner(struct cfg_set_item** begin,
+                                                     struct cfg_set_item** end,
+                                                     struct cfg_set_item** cur,
+                                                     const char* name) {
+    int res = 0;
+    int diff = 0;
+    if (cur < end && cur >= begin) {
+        res = strcmp((*cur)->name, name);
+        if (!res) {
+            return *cur;
+        } else if (res < 0 && cur > begin) {
+            diff = ((cur - begin) / 2) + 1;
+            return cfg_set_find_inner(begin, cur, cur - diff, name);
+        } else if (res > 0 && cur < end) {
+            diff = (end - cur) / 2;
+            if (!diff) {
+                diff = 1;
+            }
+            return cfg_set_find_inner(cur, end, cur + diff, name);
+        } else {
+            return NULL;
+        }
+    } else {
+        return NULL;
+    }
+}
+
+const struct cfg_set_item* cfg_set_find(const struct cfg_set* set, const char* name) {
+    size_t mid;
+    if (set->options.len) {
+        // We already know there is at least one item, so it is okay if mid is 0
+        mid = set->options.len / 2;
+        return cfg_set_find_inner(set->options.map, set->options.map + set->options.len,
+                                  set->options.map + mid, name);
+    } else {
+        return NULL;
+    }
+}
+
+int cfg_set_find_type(const struct cfg_set* set, const char* name, enum cfg_value_type type,
+                      void* data) {
+    const struct cfg_set_item* item = cfg_set_find(set, name);
+    if (item) {
+        if (item->value.type == type) {
+            switch (item->value.type) {
+            case CFG_STRING:
+            case CFG_IPV6_ADDRESS:
+            case CFG_HW_ADDRESS:
+                *(void**)data = item->value.data;
+                break;
+            case CFG_INT:
+                *(int*)data = item->value.integer;
+                break;
+            case CFG_WORD:
+                *(u_int16_t*)data = item->value.word;
+                break;
+            case CFG_BYTE:
+                *(u_int8_t*)data = item->value.byte;
+                break;
+            case CFG_BOOL:
+                *(bool*)data = item->value.boolean;
+                break;
+            default:
+                return -1;
+            }
+            return 0;
+        } else {
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+}
+
+void cfg_set_usage(const struct cfg_set* set, FILE* output) {
+    int i, longest = 0, tmp = 0;
+    if (set->usage) {
+        fprintf(output, "Usage: %s\n\n", set->usage);
+    }
+    if (set->summary) {
+        fprintf(output, "%s\n\n", set->summary);
+    }
+    if (set->parsers_sz) {
+        for (i = 0; i < set->parsers_sz; ++i) {
+            if ((tmp = strlen(set->parsers[i].long_name)) > longest) {
+                longest = tmp;
+            }
+        }
+        fprintf(output, "Available options:\n");
+        for (i = 0; i < set->parsers_sz; ++i) {
+            fprintf(output, " -%c | --%-*s  %s\n", set->parsers[i].short_name,
+                    longest, set->parsers[i].long_name, set->parsers[i].usage);
+        }
+    }
+}
+
+// Free a cfg_set
+void cfg_set_free(struct cfg_set* set) {
+    if (set && set->options.map) {
+        size_t i;
+        for (i = 0; i < set->options.len; ++i) {
+            if (set->options.map[i]) {
+                cfg_set_item_free(set->options.map[i]);
+            }
+        }
+        free(set->options.map);
+    }
+}

--- a/src/include/cfg.h
+++ b/src/include/cfg.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2017 Daniel L. Robertson
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef SYLKIE_SRC_INCLUDE_CFG_H
+#define SYLKIE_SRC_INCLUDE_CFG_H
+
+#include <sys/types.h>
+
+#include <stdbool.h>
+
+#include <sylkie_config.h>
+
+#ifdef BUILD_JSON
+#include <json-c/json.h>
+#endif
+
+//
+// cfg structures and methods
+//
+
+enum cfg_value_type {
+    CFG_INT = 0x0,
+    CFG_WORD = 0x1,
+    CFG_BYTE = 0x2,
+    CFG_STRING = 0x4,
+    CFG_IPV6_ADDRESS = 0x8,
+    CFG_HW_ADDRESS = 0x10,
+    CFG_BOOL = 0x20,
+    CFG_INVALID = 0x40,
+};
+
+struct cfg_value {
+    union {
+        void*     data;
+        int       integer;
+        u_int16_t word;
+        u_int8_t  byte;
+        bool      boolean;
+    };
+    enum cfg_value_type type;
+};
+
+struct cfg_set_item {
+    const char* name;
+    struct cfg_value value;
+};
+
+struct cfg_set;
+
+struct cfg_parser {
+    char short_name;
+    const char* long_name;
+    enum cfg_value_type type;
+    const char* usage;
+};
+
+struct cfg_map {
+    struct cfg_set_item** map;
+    size_t len;
+    size_t cap;
+};
+
+struct cfg_set {
+    const char* usage;
+    const char* summary;
+    const struct cfg_parser* parsers;
+    size_t parsers_sz;
+    struct cfg_map options;
+};
+
+struct cfg_set_item* cfg_set_item_create(const struct cfg_parser* parser, void* data);
+
+void cfg_set_item_free(struct cfg_set_item* item);
+
+int cfg_set_init_cmdline(struct cfg_set* set, size_t argc, const char** argv);
+
+#ifdef BUILD_JSON
+int cfg_set_init_json(struct cfg_set* set, struct json_object* jobj);
+#endif
+
+const struct cfg_set_item* cfg_set_find(const struct cfg_set* set, const char* name);
+
+int cfg_set_find_type(const struct cfg_set* set, const char* name, enum cfg_value_type type,
+                      void* data);
+
+// Function used to pring the help text given the parsers provided to cfg_set_init
+void cfg_set_usage(const struct cfg_set* set, FILE* output);
+
+// Free a given cfg_set item. The stored object only
+// needs to be freed if the type is a CFG_DATA
+void cfg_set_free(struct cfg_set* set);
+
+// Specific parsers frequently used by sylkie
+
+#endif

--- a/src/include/cfg.h
+++ b/src/include/cfg.h
@@ -32,9 +32,10 @@
 #endif
 
 //
-// cfg structures and methods
+// cfg_set structures and methods
 //
 
+// Valid types allowed for arguments
 enum cfg_value_type {
     CFG_INT = 0x0,
     CFG_WORD = 0x1,
@@ -46,24 +47,14 @@ enum cfg_value_type {
     CFG_INVALID = 0x40,
 };
 
-struct cfg_value {
-    union {
-        void*     data;
-        int       integer;
-        u_int16_t word;
-        u_int8_t  byte;
-        bool      boolean;
-    };
-    enum cfg_value_type type;
-};
-
-struct cfg_set_item {
-    const char* name;
-    struct cfg_value value;
-};
-
-struct cfg_set;
-
+// Structure used to define the interface for providing a given argument to a
+// command.
+//
+// Members:
+//   short_name - the single character version of the option
+//   long_name  - the string version of the option
+//   type       - the type of the value expected
+//   usage      - helpful text describing how to use the argument
 struct cfg_parser {
     char short_name;
     const char* long_name;
@@ -71,12 +62,39 @@ struct cfg_parser {
     const char* usage;
 };
 
+// Structure used to represent the value of an argument provided to a command.
+// A value may be any one of cfg_value_type.
+struct cfg_value {
+    union {
+        void* data;
+        int integer;
+        u_int16_t word;
+        u_int8_t byte;
+        bool boolean;
+    };
+    enum cfg_value_type type;
+};
+
+// An argument provided to a command. This structure includes the name of the
+// argument and the arguments value.
+//
+// NB: The items are keyed by the long_name member of the cfg_parser struct
+// __not__ the short_name.
+struct cfg_set_item {
+    const char* name;
+    struct cfg_value value;
+};
+
+// A container structure for B-Tree containing a given number of arguments and
+// their associated values.
 struct cfg_map {
     struct cfg_set_item** map;
     size_t len;
     size_t cap;
 };
 
+// The main structure a user uses to maintain state while using the cfg_set
+// argument parsing framework
 struct cfg_set {
     const char* usage;
     const char* summary;
@@ -85,28 +103,42 @@ struct cfg_set {
     struct cfg_map options;
 };
 
-struct cfg_set_item* cfg_set_item_create(const struct cfg_parser* parser, void* data);
+// Create a new cfg_set_item from a parser and a pointer to the value
+struct cfg_set_item* cfg_set_item_create(const struct cfg_parser* parser,
+                                         void* data);
 
+// Free any allocated resources associated with an item. This is at a minumum
+// sizeof(struct cfg_set_item), but may also be the size of the data contained
+// depending on the value type.
 void cfg_set_item_free(struct cfg_set_item* item);
 
+// Populate the cfg_set map with the user provided arguments and values from
+// argv/argc
 int cfg_set_init_cmdline(struct cfg_set* set, size_t argc, const char** argv);
 
 #ifdef BUILD_JSON
+// Populate the cfg_set map with the user provided arguments and values from
+// the given json_object
 int cfg_set_init_json(struct cfg_set* set, struct json_object* jobj);
 #endif
 
-const struct cfg_set_item* cfg_set_find(const struct cfg_set* set, const char* name);
+// Search the cfg_sets btree by name and return a pointer to the entire item.
+// When a lookup fails, the returned value is NULL
+const struct cfg_set_item* cfg_set_find(const struct cfg_set* set,
+                                        const char* name);
 
-int cfg_set_find_type(const struct cfg_set* set, const char* name, enum cfg_value_type type,
-                      void* data);
+// Search the cfg_sets btree by name and type. If a match is found, set the
+// memory pointed to by the data argument to the given value. If no match
+// is found, do not mutate the data argument, but rather return -1
+int cfg_set_find_type(const struct cfg_set* set, const char* name,
+                      enum cfg_value_type type, void* data);
 
-// Function used to pring the help text given the parsers provided to cfg_set_init
+// Function used to pring the help text given the parsers provided to
+// cfg_set_init
 void cfg_set_usage(const struct cfg_set* set, FILE* output);
 
 // Free a given cfg_set item. The stored object only
 // needs to be freed if the type is a CFG_DATA
 void cfg_set_free(struct cfg_set* set);
-
-// Specific parsers frequently used by sylkie
 
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -28,7 +28,7 @@
 
 u_int8_t hex_char_to_byte(char ch);
 
-int parse_hwaddr(const char* arg, u_int8_t addr[ETH_ALEN]);
+int parse_hwaddr(const char* arg, u_int8_t* addr);
 
 int lockdown(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -34,8 +34,8 @@
 #include <json-c/json.h>
 #endif
 
-#include <cfg.h>
 #include <buffer.h>
+#include <cfg.h>
 #include <cmds.h>
 
 struct pid_buf {
@@ -236,8 +236,7 @@ int run_from_json(const char* arg, struct pid_buf* pid_buf) {
 static struct cfg_parser parsers[] = {
     {'h', "help", CFG_BOOL, "print helpful usage information"},
     {'v', "version", CFG_BOOL, "print the version number of sylkie"},
-    {'j', "json", CFG_STRING, "parse input from the provided json file"}
-};
+    {'j', "json", CFG_STRING, "parse input from the provided json file"}};
 static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
 int main(int argc, const char** argv) {
@@ -248,8 +247,7 @@ int main(int argc, const char** argv) {
         .usage = "sylkie [ OPTIONS | SUBCOMMAND ]",
         .summary = "IPv6 address spoofing with the Neighbor Discovery Protocol",
         .parsers = parsers,
-        .parsers_sz = parsers_sz
-    };
+        .parsers_sz = parsers_sz};
     struct pid_buf* pid_buf = NULL;
 
     if (argc < 2) {
@@ -257,7 +255,6 @@ int main(int argc, const char** argv) {
         cfg_set_usage(&set, stderr);
         return -1;
     }
-
 
     --argc;
     ++argv;

--- a/src/na.c
+++ b/src/na.c
@@ -34,70 +34,72 @@
 #include <json-c/json.h>
 #endif
 
+#include <cfg.h>
 #include <utils.h>
 
-void na_usage(FILE* fd) {
-    fprintf(
-        fd,
-        "Usage: sylkie na [OPTION]\n"
-        "Send ICMPv6 Neighbor Advertisement messages to the given address\n\n"
-        "Available options:\n"
-        " -h | --help        this\n"
-        " -i | --interface   interface that will be used to send packets\n"
-        " -s | --src-mac     source address in ethernet frame\n"
-        " -d | --dst-mac     destination address in ethernet frame\n"
-        " -S | --src-ip      source ipv6 address in IP header\n"
-        " -D | --dst-ip      destination ipv6 address in IP header\n"
-        " -T | --target-ip   target address of Neighbor Advertisement\n"
-        " -t | --target-mac  link-layer address used as value for the target\n"
-        "                    address option of the Neighbor Advertisement\n"
-        " -r | --repeat      send the packet <num> times\n"
-        " -z | --timeout     wait <seconds> before sending the packet again\n");
-}
+static struct cfg_parser parsers[] = {
+    {'h', "help", CFG_BOOL, "print helpful usage information"},
+    {'i', "interface", CFG_STRING, "network interface that will be used to send packets"},
+    {'s', "src-mac", CFG_HW_ADDRESS, "source address for the ethernet frame"},
+    {'d', "dst-mac", CFG_HW_ADDRESS, "destination address for the ethernet frame"},
+    {'t', "target-mac", CFG_HW_ADDRESS, "link layer address used for the target address "
+                                        "option of the advertisement"},
+    {'S', "src-ip", CFG_IPV6_ADDRESS, "source ipv6 address in IPv6 header"},
+    {'D', "dst-ip", CFG_IPV6_ADDRESS, "destination ipv6 address in IPv6 header"},
+    {'T', "target-ip", CFG_IPV6_ADDRESS, "target address of the Neighbor Advertisement"},
+    {'r', "repeat", CFG_INT, "send the packet <num> times"},
+    {'z', "timeout", CFG_INT, "wait <seconds> before sending the packet agein"}
+};
+static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
-int inner_do_na(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
-                u_int8_t* tgt_mac, struct in6_addr* src_addr,
-                struct in6_addr* dst_addr, struct in6_addr* tgt_addr,
-                int repeat, int timeout) {
-    int i, res = 0, retval = 0;
+int inner_do_na(const struct cfg_set* set) {
+    int retval = -1, prefix = 64, timeout = 1, repeat = 1, i = 0;
+    const char* iface_name;
+    const u_int8_t* dst_mac = NULL;
+    const u_int8_t* src_mac = NULL;
+    const u_int8_t* tgt_mac = NULL;
+    struct in6_addr* dst_addr;
+    struct in6_addr* src_addr;
+    struct in6_addr* tgt_addr;
     enum sylkie_error err = SYLKIE_INVALID_ERR;
     struct sylkie_sender* sender = NULL;
     struct sylkie_packet* pkt = NULL;
-    if (!iface_name) {
+
+    // Required input
+    if(cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
         fprintf(stderr, "Must provide an interface to use.\n");
-        na_usage(stderr);
+        cfg_set_usage(set, stderr);
         _exit(-1);
-    } else if (!dst_mac) {
+    } else if (cfg_set_find_type(set, "dst-mac", CFG_HW_ADDRESS, &dst_mac)) {
         fprintf(stderr, "Must provide a destination mac address.\n");
-        na_usage(stderr);
+        cfg_set_usage(set, stderr);
         _exit(-1);
-    } else if (!src_addr) {
-        fprintf(stderr, "Must provide a source ip address.\n");
-        na_usage(stderr);
-        _exit(-1);
-    } else if (!dst_addr) {
+    } else if (cfg_set_find_type(set, "dst-ip", CFG_IPV6_ADDRESS, &dst_addr)) {
         fprintf(stderr, "Must provide a destination ip address.\n");
-        na_usage(stderr);
+        cfg_set_usage(set, stderr);
+        _exit(-1);
+    } else if (cfg_set_find_type(set, "src-ip", CFG_IPV6_ADDRESS, &src_addr)) {
+        fprintf(stderr, "Must provide a source ip address.\n");
+        cfg_set_usage(set, stderr);
         _exit(-1);
     }
 
+    // Optional input
     sender = sylkie_sender_init(iface_name, &err);
 
     if (err || !sender) {
         fprintf(stderr, "%s\n", sylkie_strerror(err));
         _exit(-1);
-    }
-
-    if (!src_mac) {
+    } else if (cfg_set_find_type(set, "src-mac", CFG_HW_ADDRESS, &src_mac)) {
         src_mac = sender->addr.sll_addr;
     }
 
-    if (!tgt_addr) {
-        tgt_addr = src_addr;
+    if (cfg_set_find_type(set, "target-mac", CFG_HW_ADDRESS, &tgt_mac)) {
+        tgt_mac = src_mac;
     }
 
-    if (!tgt_mac) {
-        tgt_mac = src_mac;
+    if (cfg_set_find_type(set, "target-ip", CFG_IPV6_ADDRESS, &tgt_addr)) {
+        tgt_addr = src_addr;
     }
 
     pkt = sylkie_neighbor_advert_create(src_mac, dst_mac, src_addr, dst_addr,
@@ -108,10 +110,14 @@ int inner_do_na(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
         _exit(-1);
     }
 
+    cfg_set_find_type(set, "prefix", CFG_BYTE, &prefix);
+    cfg_set_find_type(set, "timeout", CFG_INT, &timeout);
+    cfg_set_find_type(set, "repeat", CFG_INT, &repeat);
+
     if (repeat <= 0) {
         while (1) {
-            res = sylkie_sender_send_packet(sender, pkt, 0, &err);
-            if (err || res < 0) {
+            retval = sylkie_sender_send_packet(sender, pkt, 0, &err);
+            if (err || retval < 0) {
                 fprintf(stderr, "SYLKIE Error:%s\nErrno: %s",
                         sylkie_strerror(err), strerror(errno));
                 retval = -1;
@@ -124,8 +130,8 @@ int inner_do_na(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
         }
     } else {
         for (i = 0; i < repeat; ++i) {
-            res = sylkie_sender_send_packet(sender, pkt, 0, &err);
-            if (err || res < 0) {
+            retval = sylkie_sender_send_packet(sender, pkt, 0, &err);
+            if (err || retval < 0) {
                 fprintf(stderr, "SYLKIE Error:%s\nErrno: %s",
                         sylkie_strerror(err), strerror(errno));
                 retval = -1;
@@ -147,258 +153,72 @@ int inner_do_na(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
 
 #ifdef BUILD_JSON
 pid_t na_json(struct json_object* jobj) {
+    int res = -1;
     pid_t pid = -1;
-    int res = 0, repeat = 1, timeout = 0;
-    const char* tmp;
-    const char* iface_name = NULL;
-    u_int8_t* src_mac = NULL;
-    u_int8_t* dst_mac = NULL;
-    u_int8_t* tgt_mac = NULL;
-    u_int8_t src_mac_opt[8], dst_mac_opt[8], tgt_mac_opt[8];
-    struct in6_addr src_addr_opt, dst_addr_opt, tgt_addr_opt;
-    struct in6_addr* src_addr = NULL;
-    struct in6_addr* dst_addr = NULL;
-    struct in6_addr* tgt_addr = NULL;
-    enum json_type type;
-    json_object_object_foreach(jobj, key, val) {
-        type = json_object_get_type(val);
-        if (strcmp(key, "interface") == 0) {
-            if (type == json_type_string) {
-                iface_name = json_object_get_string(val);
-            } else {
-                fprintf(stderr, "Invalid type for interface\n");
-                return -1;
-            }
-        } else if (strcmp(key, "src-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, src_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                src_mac = src_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for src-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "dst-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, dst_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                dst_mac = dst_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for dst-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "target-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, tgt_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                tgt_mac = tgt_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for target-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "src-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &src_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    na_usage(stderr);
-                    _exit(-1);
-                }
-                src_addr = &src_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for src-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "dst-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &dst_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    na_usage(stderr);
-                    _exit(-1);
-                }
-                dst_addr = &dst_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for dst-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "target-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &tgt_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    na_usage(stderr);
-                    _exit(-1);
-                }
-                tgt_addr = &tgt_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for target-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "repeat") == 0) {
-            if (type == json_type_int) {
-                repeat = json_object_get_int(val);
-            } else {
-                fprintf(stderr, "Invalid type for repeat\n");
-                return -1;
-            }
-        } else if (strcmp(key, "timeout") == 0) {
-            if (type == json_type_int) {
-                timeout = json_object_get_int(val);
-            } else {
-                fprintf(stderr, "Invalid type for timeout\n");
-                return -1;
-            }
-        } else {
-            fprintf(stderr, "Unknown key: %s\n", key);
-            return -1;
-        }
+    struct cfg_set set = {
+        .usage = "sylkie na [OPTIONS]",
+        .summary = "Send ICMPv6 Neighbor Advertisement messages to the given address",
+        .parsers = parsers,
+        .parsers_sz = parsers_sz
+    };
+
+    res = cfg_set_init_json(&set, jobj);
+
+    if (res) {
+        fprintf(stderr, "Failed to initialize parsers\n");
+        return -1;
+    } else if (cfg_set_find(&set, "help")) {
+        fprintf(stderr, "\"help\" is an invalid option for running sylkie from json\n");
+        cfg_set_free(&set);
+        return -1;
     }
 
     if ((pid = fork()) < 0) {
+        cfg_set_free(&set);
         return -1;
     } else if (pid == 0) {
         if (lockdown()) {
             fprintf(stderr, "Could not lock down the process\n");
             _exit(-1);
         }
-        res = inner_do_na(iface_name, src_mac, dst_mac, tgt_mac, src_addr,
-                          dst_addr, tgt_addr, repeat, timeout);
+        res = inner_do_na(&set);
         exit(res);
     } else {
+        cfg_set_free(&set);
         return pid;
     }
 }
 #endif
 
 int na_cmdline(int argc, const char** argv) {
-    int i = 1, res = -1, repeat = 1, timeout = 0;
-    u_int8_t* src_mac = NULL;
-    u_int8_t* dst_mac = NULL;
-    u_int8_t* tgt_mac = NULL;
-    u_int8_t src_mac_opt[8], dst_mac_opt[8], tgt_mac_opt[8];
-    const char* iface_name = NULL;
-    struct in6_addr src_addr_opt, dst_addr_opt, tgt_addr_opt;
-    struct in6_addr* src_addr = NULL;
-    struct in6_addr* dst_addr = NULL;
-    struct in6_addr* tgt_addr = NULL;
+    int res = -1;
+    struct cfg_set set = {
+        .usage = "sylkie na [OPTIONS]",
+        .summary = "Send ICMPv6 Neighbor Advertisement messages to the given address",
+        .parsers = parsers,
+        .parsers_sz = parsers_sz
+    };
 
-    if (argc < 2) {
+    if (argc < 1) {
         fprintf(stderr, "Too few arguments\n");
-        na_usage(stderr);
-        _exit(-1);
+        cfg_set_usage(&set, stderr);
+        return -1;
     }
 
-    while (i < argc) {
-        if (ARG_CMP(argv[i], "-h", "--help")) {
-            na_usage(stdout);
-            _exit(0);
-        } else if (!(i + 1 <= argc)) {
-            fprintf(stderr, "%s requires an argument\n", argv[i]);
-            na_usage(stderr);
-            _exit(-1);
-        } else if (ARG_CMP(argv[i], "-i", "--interface")) {
-            ++i;
-            iface_name = argv[i];
-        } else if (ARG_CMP(argv[i], "-s", "--src-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], src_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            src_mac = src_mac_opt;
-        } else if (ARG_CMP(argv[i], "-d", "--dst-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], dst_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            dst_mac = dst_mac_opt;
-        } else if (ARG_CMP(argv[i], "-t", "--target-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], tgt_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            tgt_mac = tgt_mac_opt;
-        } else if (ARG_CMP(argv[i], "-S", "--src-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &src_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                na_usage(stderr);
-                _exit(-1);
-            }
-            src_addr = &src_addr_opt;
-        } else if (ARG_CMP(argv[i], "-D", "--dst-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &dst_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                na_usage(stderr);
-                _exit(-1);
-            }
-            dst_addr = &dst_addr_opt;
-        } else if (ARG_CMP(argv[i], "-T", "--target-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &tgt_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                na_usage(stderr);
-                _exit(-1);
-            }
-            tgt_addr = &tgt_addr_opt;
-        } else if (ARG_CMP(argv[i], "-r", "--repeat")) {
-            ++i;
-            repeat = atoi(argv[i]);
-            if (repeat <= 0) {
-                if (strcmp(argv[i], "-1") == 0) {
-                    repeat = -1;
-                } else {
-                    fprintf(stderr, "%s is not a valid repeat value", argv[i]);
-                    na_usage(stderr);
-                    _exit(-1);
-                }
-            }
-        } else if (ARG_CMP(argv[i], "-z", "--timeout")) {
-            ++i;
-            timeout = atoi(argv[i]);
-            if (timeout < 0) {
-                fprintf(stderr, "%s is not a valid timout value", argv[i]);
-                na_usage(stderr);
-                _exit(-1);
-            }
-        } else {
-            fprintf(stderr, "Unknown option: %s\n", argv[i]);
-            na_usage(stderr);
-            _exit(-1);
-        }
-        ++i;
+    res = cfg_set_init_cmdline(&set, --argc, ++argv);
+
+    if (res) {
+        cfg_set_usage(&set, stderr);
+        return -1;
+    } else if (cfg_set_find(&set, "help")) {
+        cfg_set_usage(&set, stdout);
+        cfg_set_free(&set);
+        return 0;
+    } else {
+        res = inner_do_na(&set);
     }
-    return inner_do_na(iface_name, src_mac, dst_mac, tgt_mac, src_addr,
-                       dst_addr, tgt_addr, repeat, timeout);
+
+    cfg_set_free(&set);
+
+    return res;
 }

--- a/src/na.c
+++ b/src/na.c
@@ -39,17 +39,22 @@
 
 static struct cfg_parser parsers[] = {
     {'h', "help", CFG_BOOL, "print helpful usage information"},
-    {'i', "interface", CFG_STRING, "network interface that will be used to send packets"},
+    {'i', "interface", CFG_STRING,
+     "network interface that will be used to send packets"},
     {'s', "src-mac", CFG_HW_ADDRESS, "source address for the ethernet frame"},
-    {'d', "dst-mac", CFG_HW_ADDRESS, "destination address for the ethernet frame"},
-    {'t', "target-mac", CFG_HW_ADDRESS, "link layer address used for the target address "
-                                        "option of the advertisement"},
+    {'d', "dst-mac", CFG_HW_ADDRESS,
+     "destination address for the ethernet frame"},
+    {'t', "target-mac", CFG_HW_ADDRESS,
+     "link layer address used for the target address "
+     "option of the advertisement"},
     {'S', "src-ip", CFG_IPV6_ADDRESS, "source ipv6 address in IPv6 header"},
-    {'D', "dst-ip", CFG_IPV6_ADDRESS, "destination ipv6 address in IPv6 header"},
-    {'T', "target-ip", CFG_IPV6_ADDRESS, "target address of the Neighbor Advertisement"},
+    {'D', "dst-ip", CFG_IPV6_ADDRESS,
+     "destination ipv6 address in IPv6 header"},
+    {'T', "target-ip", CFG_IPV6_ADDRESS,
+     "target address of the Neighbor Advertisement"},
     {'r', "repeat", CFG_INT, "send the packet <num> times"},
-    {'z', "timeout", CFG_INT, "wait <seconds> before sending the packet agein"}
-};
+    {'z', "timeout", CFG_INT,
+     "wait <seconds> before sending the packet agein"}};
 static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
 int inner_do_na(const struct cfg_set* set) {
@@ -66,7 +71,7 @@ int inner_do_na(const struct cfg_set* set) {
     struct sylkie_packet* pkt = NULL;
 
     // Required input
-    if(cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
+    if (cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
         fprintf(stderr, "Must provide an interface to use.\n");
         cfg_set_usage(set, stderr);
         _exit(-1);
@@ -157,10 +162,10 @@ pid_t na_json(struct json_object* jobj) {
     pid_t pid = -1;
     struct cfg_set set = {
         .usage = "sylkie na [OPTIONS]",
-        .summary = "Send ICMPv6 Neighbor Advertisement messages to the given address",
+        .summary =
+            "Send ICMPv6 Neighbor Advertisement messages to the given address",
         .parsers = parsers,
-        .parsers_sz = parsers_sz
-    };
+        .parsers_sz = parsers_sz};
 
     res = cfg_set_init_json(&set, jobj);
 
@@ -168,7 +173,8 @@ pid_t na_json(struct json_object* jobj) {
         fprintf(stderr, "Failed to initialize parsers\n");
         return -1;
     } else if (cfg_set_find(&set, "help")) {
-        fprintf(stderr, "\"help\" is an invalid option for running sylkie from json\n");
+        fprintf(stderr,
+                "\"help\" is an invalid option for running sylkie from json\n");
         cfg_set_free(&set);
         return -1;
     }
@@ -194,10 +200,10 @@ int na_cmdline(int argc, const char** argv) {
     int res = -1;
     struct cfg_set set = {
         .usage = "sylkie na [OPTIONS]",
-        .summary = "Send ICMPv6 Neighbor Advertisement messages to the given address",
+        .summary =
+            "Send ICMPv6 Neighbor Advertisement messages to the given address",
         .parsers = parsers,
-        .parsers_sz = parsers_sz
-    };
+        .parsers_sz = parsers_sz};
 
     if (argc < 1) {
         fprintf(stderr, "Too few arguments\n");
@@ -215,6 +221,7 @@ int na_cmdline(int argc, const char** argv) {
         cfg_set_free(&set);
         return 0;
     } else {
+        lockdown();
         res = inner_do_na(&set);
     }
 

--- a/src/ra.c
+++ b/src/ra.c
@@ -34,49 +34,74 @@
 #include <json-c/json.h>
 #endif
 
+#include <cfg.h>
 #include <utils.h>
 
-void ra_usage(FILE* fd) {
-    fprintf(
-        fd,
-        "Usage: sylkie ra [OPTION]\n"
-        "Send ICMPv6 Router Advertisement messages to the given address\n\n"
-        "Available options:\n"
-        " -h | --help        this\n"
-        " -i | --interface   interface that will be used to send packets\n"
-        " -s | --src-mac     source address in ethernet frame\n"
-        " -d | --dst-mac     destination address in ethernet frame\n"
-        " -S | --src-ip      source ipv6 address in IP header\n"
-        " -D | --dst-ip      destination ipv6 address in IP header\n"
-        " -t | --target-mac  link-layer address used as value for the target\n"
-        "                    address option of the Neighbor Advertisement\n"
-        " -r | --repeat      send the packet <num> times\n"
-        " -z | --timeout     wait <seconds> before sending the packet again\n");
-}
 
-int inner_do_ra(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
-                u_int8_t* tgt_mac, struct in6_addr* src_addr,
-                struct in6_addr* dst_addr, struct in6_addr* tgt_addr,
-                u_int8_t prefix, int repeat, int timeout) {
-    int i, res = 0, retval = 0;
-    struct in6_addr dst_addr_opt;
-    u_int8_t dst_mac_opt[ETH_ALEN] = {0x33, 0x33, 0x00, 0x00, 0x00, 0x01};
+static struct cfg_parser parsers[] = {
+    {'h', "help", CFG_BOOL, "print helpful usage information"},
+    {'i', "interface", CFG_STRING, "network interface that will be used to send packets"},
+    {'s', "src-mac", CFG_HW_ADDRESS, "source address for the ethernet frame"},
+    {'d', "dst-mac", CFG_HW_ADDRESS, "destination address for the ethernet frame"},
+    {'S', "src-ip", CFG_IPV6_ADDRESS, "source ipv6 address in IPv6 header"},
+    {'D', "dst-ip", CFG_IPV6_ADDRESS, "destination ipv6 address in IPv6 header"},
+    {'t', "target-mac", CFG_HW_ADDRESS, "link layer address used for the target address "
+                                        "option of the advertisement"},
+    {'R', "router-ip", CFG_IPV6_ADDRESS, "ipv6 address of the router to spoof"},
+    {'r', "repeat", CFG_INT, "send the packet <num> times"},
+    {'z', "timeout", CFG_INT, "wait <seconds> before sending the packet agein"}
+};
+static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
+
+int inner_do_ra(const struct cfg_set* set) {
+    int retval = -1, prefix = 64, timeout = 1, repeat = 1, i = 0;
     enum sylkie_error err = SYLKIE_INVALID_ERR;
     struct sylkie_sender* sender = NULL;
     struct sylkie_packet* pkt = NULL;
-    if (!iface_name) {
+    static const u_int8_t all_nodes_eth[] = {
+        0x33, 0x33, 0x00, 0x00, 0x00, 0x01
+    };
+    static struct in6_addr all_nodes_ip = {
+        .s6_addr = {
+            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }
+    };
+    char* iface_name = NULL;
+    const u_int8_t* dst_mac = NULL;
+    const u_int8_t* src_mac = NULL;
+    const u_int8_t* tgt_mac = NULL;
+    struct in6_addr* dst_addr = NULL;
+    struct in6_addr* router_addr = NULL;
+    struct in6_addr* src_addr = NULL;
+
+    if(cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
         fprintf(stderr, "Must provide an interface to use.\n");
-        ra_usage(stderr);
+        cfg_set_usage(set, stderr);
         _exit(-1);
-    } else if ((!dst_mac && dst_addr) || (dst_mac && !dst_addr)) {
+    }
+
+    cfg_set_find_type(set, "dst-mac", CFG_HW_ADDRESS, &dst_mac);
+    cfg_set_find_type(set, "dst-ip", CFG_IPV6_ADDRESS, &dst_addr);
+    cfg_set_find_type(set, "src-ip", CFG_IPV6_ADDRESS, &src_addr);
+    cfg_set_find_type(set, "router-ip", CFG_IPV6_ADDRESS, &router_addr);
+
+    if (!dst_mac && !dst_addr) {
+        dst_mac = all_nodes_eth;
+        dst_addr = &all_nodes_ip;
+    } else if (!(dst_mac && dst_addr)) {
         fprintf(stderr, "Must provide a destination mac and ip"
                         " address or none at all.\n");
-        ra_usage(stderr);
+        cfg_set_usage(set, stderr);
         _exit(-1);
-    } else if (!src_addr && !tgt_addr) {
-        fprintf(stderr, "Must provide a source or target ip address.\n");
-        ra_usage(stderr);
+    }
+
+    if (!router_addr) {
+        fprintf(stderr, "Must provide a router ip address to spoof.\n");
+        cfg_set_usage(set, stderr);
         _exit(-1);
+    } else if (!src_addr) {
+        src_addr = router_addr;
     }
 
     sender = sylkie_sender_init(iface_name, &err);
@@ -86,40 +111,35 @@ int inner_do_ra(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
         _exit(-1);
     }
 
-    if (!dst_addr) {
-        inet_pton(AF_INET6, "ff02::1", &dst_addr_opt);
-        dst_addr = &dst_addr_opt;
-        dst_mac = dst_mac_opt;
-    }
-
-    if (!tgt_addr) {
-        tgt_addr = src_addr;
-    }
-
-    if (!src_addr) {
-        src_addr = tgt_addr;
-    }
-
-    if (!src_mac) {
+    if (cfg_set_find_type(set, "src-mac", CFG_HW_ADDRESS, &src_mac)) {
         src_mac = sender->addr.sll_addr;
     }
 
-    if (!tgt_mac) {
+    if (cfg_set_find_type(set, "target-mac", CFG_HW_ADDRESS, &tgt_mac)) {
         tgt_mac = src_mac;
     }
 
     pkt = sylkie_router_advert_create(src_mac, dst_mac, src_addr, dst_addr,
-                                      tgt_addr, prefix, tgt_mac, &err);
+                                      router_addr, prefix, tgt_mac, &err);
 
     if (!pkt) {
         fprintf(stderr, "%s\n", "Could not allocate packet");
         _exit(-1);
     }
 
+    cfg_set_find_type(set, "prefix", CFG_BYTE, &prefix);
+    cfg_set_find_type(set, "timeout", CFG_INT, &timeout);
+    cfg_set_find_type(set, "repeat", CFG_INT, &repeat);
+
+    if (timeout < 0) {
+        fprintf(stderr, "%s\n", "timeout must be greater than or equal to 0");
+        _exit(-1);
+    }
+
     if (repeat <= 0) {
         while (1) {
-            res = sylkie_sender_send_packet(sender, pkt, 0, &err);
-            if (err || res < 0) {
+            retval = sylkie_sender_send_packet(sender, pkt, 0, &err);
+            if (err || retval < 0) {
                 fprintf(stderr, "SYLKIE Error:%s\nErrno: %s",
                         sylkie_strerror(err), strerror(errno));
                 retval = -1;
@@ -132,8 +152,8 @@ int inner_do_ra(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
         }
     } else {
         for (i = 0; i < repeat; ++i) {
-            res = sylkie_sender_send_packet(sender, pkt, 0, &err);
-            if (err || res < 0) {
+            retval = sylkie_sender_send_packet(sender, pkt, 0, &err);
+            if (err || retval < 0) {
                 fprintf(stderr, "SYLKIE Error:%s\nErrno: %s",
                         sylkie_strerror(err), strerror(errno));
                 retval = -1;
@@ -155,280 +175,72 @@ int inner_do_ra(const char* iface_name, u_int8_t* src_mac, u_int8_t* dst_mac,
 
 #ifdef BUILD_JSON
 pid_t ra_json(struct json_object* jobj) {
+    int res = -1;
     pid_t pid = -1;
-    int res = 0, repeat = 1, timeout = 0;
-    u_int8_t prefix = 64;
-    const char* tmp;
-    const char* iface_name = NULL;
-    u_int8_t* src_mac = NULL;
-    u_int8_t* dst_mac = NULL;
-    u_int8_t* tgt_mac = NULL;
-    u_int8_t src_mac_opt[8], dst_mac_opt[8], tgt_mac_opt[8];
-    struct in6_addr src_addr_opt, dst_addr_opt, tgt_addr_opt;
-    struct in6_addr* src_addr = NULL;
-    struct in6_addr* dst_addr = NULL;
-    struct in6_addr* tgt_addr = NULL;
-    enum json_type type;
-    json_object_object_foreach(jobj, key, val) {
-        type = json_object_get_type(val);
-        if (strcmp(key, "interface") == 0) {
-            if (type == json_type_string) {
-                iface_name = json_object_get_string(val);
-            } else {
-                fprintf(stderr, "Invalid type for interface\n");
-                return -1;
-            }
-        } else if (strcmp(key, "src-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, src_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                src_mac = src_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for src-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "dst-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, dst_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                dst_mac = dst_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for dst-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "target-mac") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = parse_hwaddr(tmp, tgt_mac_opt);
-                if (res < 0) {
-                    fprintf(stderr, "Could not parse mac: %s\n", tmp);
-                    return -1;
-                }
-                tgt_mac = tgt_mac_opt;
-            } else {
-                fprintf(stderr, "Invalid type for target-mac\n");
-                return -1;
-            }
-        } else if (strcmp(key, "src-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &src_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    ra_usage(stderr);
-                    _exit(-1);
-                }
-                src_addr = &src_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for src-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "dst-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &dst_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    ra_usage(stderr);
-                    _exit(-1);
-                }
-                dst_addr = &dst_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for dst-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "router-ip") == 0) {
-            if (type == json_type_string) {
-                tmp = json_object_get_string(val);
-                res = inet_pton(AF_INET6, tmp, &tgt_addr_opt);
-                if (res <= 0) {
-                    fprintf(stderr, "Could not parse %s - %s\n", tmp,
-                            strerror(errno));
-                    ra_usage(stderr);
-                    _exit(-1);
-                }
-                tgt_addr = &tgt_addr_opt;
-            } else {
-                fprintf(stderr, "Invalid type for dst-ip\n");
-                return -1;
-            }
-        } else if (strcmp(key, "prefix") == 0) {
-            if (type == json_type_int) {
-                res = json_object_get_int(val);
-                if (res <= 128) {
-                    prefix = (u_int8_t)res;
-                } else {
-                    fprintf(stderr, "%d is too large for an ipv6 prefix\n",
-                            res);
-                    return -1;
-                }
-            }
-        } else if (strcmp(key, "repeat") == 0) {
-            if (type == json_type_int) {
-                repeat = json_object_get_int(val);
-            } else {
-                fprintf(stderr, "Invalid type for repeat\n");
-                return -1;
-            }
-        } else if (strcmp(key, "timeout") == 0) {
-            if (type == json_type_int) {
-                timeout = json_object_get_int(val);
-            } else {
-                fprintf(stderr, "Invalid type for timeout\n");
-                return -1;
-            }
-        } else {
-            fprintf(stderr, "Unknown key: %s\n", key);
-            return -1;
-        }
+    struct cfg_set set = {
+        .usage = "sylkie ra [OPTIONS]",
+        .summary = "Send ICMPv6 Router Advertisement messages to the given address",
+        .parsers = parsers,
+        .parsers_sz = parsers_sz
+    };
+
+    res = cfg_set_init_json(&set, jobj);
+
+    if (res) {
+        fprintf(stderr, "Failed to initialize parsers\n");
+        return -1;
+    } else if (cfg_set_find(&set, "help")) {
+        fprintf(stderr, "\"help\" is an invalid option for running sylkie from json\n");
+        cfg_set_free(&set);
+        return -1;
     }
 
     if ((pid = fork()) < 0) {
+        cfg_set_free(&set);
         return -1;
     } else if (pid == 0) {
         if (lockdown()) {
             fprintf(stderr, "Could not lock down the process\n");
             _exit(-1);
         }
-        res = inner_do_ra(iface_name, src_mac, dst_mac, tgt_mac, src_addr,
-                          dst_addr, tgt_addr, prefix, repeat, timeout);
+        res = inner_do_ra(&set);
         exit(res);
     } else {
+        cfg_set_free(&set);
         return pid;
     }
 }
 #endif
 
 int ra_cmdline(int argc, const char** argv) {
-    int i = 1, res = -1, repeat = 1, timeout = 0;
-    u_int8_t prefix = 64;
-    u_int8_t* src_mac = NULL;
-    u_int8_t* dst_mac = NULL;
-    u_int8_t* tgt_mac = NULL;
-    u_int8_t src_mac_opt[8], dst_mac_opt[8], tgt_mac_opt[8];
-    const char* iface_name = NULL;
-    struct in6_addr src_addr_opt, dst_addr_opt, tgt_addr_opt;
-    struct in6_addr* src_addr = NULL;
-    struct in6_addr* dst_addr = NULL;
-    struct in6_addr* tgt_addr = NULL;
+    int res = -1;
+    struct cfg_set set = {
+        .usage = "sylkie ra [OPTIONS]",
+        .summary = "Send ICMPv6 Router Advertisement messages to the given address",
+        .parsers = parsers,
+        .parsers_sz = parsers_sz
+    };
 
-    if (argc < 2) {
+    if (argc < 1) {
         fprintf(stderr, "Too few arguments\n");
-        ra_usage(stderr);
-        _exit(-1);
+        cfg_set_usage(&set, stderr);
+        return -1;
     }
 
-    while (i < argc) {
-        if (ARG_CMP(argv[i], "-h", "--help")) {
-            ra_usage(stdout);
-            _exit(0);
-        } else if (!(i + 1 <= argc)) {
-            fprintf(stderr, "%s requires an argument\n", argv[i]);
-            ra_usage(stderr);
-            _exit(-1);
-        } else if (ARG_CMP(argv[i], "-i", "--interface")) {
-            ++i;
-            iface_name = argv[i];
-        } else if (ARG_CMP(argv[i], "-s", "--src-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], src_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            src_mac = src_mac_opt;
-        } else if (ARG_CMP(argv[i], "-d", "--dst-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], dst_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            dst_mac = dst_mac_opt;
-        } else if (ARG_CMP(argv[i], "-t", "--target-mac")) {
-            ++i;
-            res = parse_hwaddr(argv[i], tgt_mac_opt);
-            if (res < 0) {
-                fprintf(stderr, "Could not parse mac: %s\n", argv[i]);
-                _exit(-1);
-            }
-            tgt_mac = tgt_mac_opt;
-        } else if (ARG_CMP(argv[i], "-S", "--src-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &src_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                ra_usage(stderr);
-                _exit(-1);
-            }
-            src_addr = &src_addr_opt;
-        } else if (ARG_CMP(argv[i], "-D", "--dst-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &dst_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                ra_usage(stderr);
-                _exit(-1);
-            }
-            dst_addr = &dst_addr_opt;
-        } else if (ARG_CMP(argv[i], "-R", "--router-ip")) {
-            ++i;
-            res = inet_pton(AF_INET6, argv[i], &tgt_addr_opt);
-            if (res <= 0) {
-                fprintf(stderr, "Could not parse %s - %s\n", argv[i],
-                        strerror(errno));
-                ra_usage(stderr);
-                _exit(-1);
-            }
-            tgt_addr = &tgt_addr_opt;
-        } else if (ARG_CMP(argv[i], "-p", "--prefix")) {
-            ++i;
-            res = atoi(argv[i]);
-            if (res <= 0 || res >= 128) {
-                fprintf(stderr, "%s is not a valid prefix value", argv[i]);
-                ra_usage(stderr);
-                _exit(-1);
-            }
-            prefix = (u_int8_t)res;
-        } else if (ARG_CMP(argv[i], "-r", "--repeat")) {
-            ++i;
-            repeat = atoi(argv[i]);
-            if (repeat <= 0) {
-                if (strcmp(argv[i], "-1") == 0) {
-                    repeat = -1;
-                } else {
-                    fprintf(stderr, "%s is not a valid repeat value", argv[i]);
-                    ra_usage(stderr);
-                    _exit(-1);
-                }
-            }
-        } else if (ARG_CMP(argv[i], "-z", "--timeout")) {
-            ++i;
-            timeout = atoi(argv[i]);
-            if (timeout < 0) {
-                fprintf(stderr, "%s is not a valid timout value", argv[i]);
-                ra_usage(stderr);
-                _exit(-1);
-            }
-        } else {
-            fprintf(stderr, "Unknown option: %s\n", argv[i]);
-            ra_usage(stderr);
-            _exit(-1);
-        }
-        ++i;
+    res = cfg_set_init_cmdline(&set, --argc, ++argv);
+
+    if (res) {
+        cfg_set_usage(&set, stderr);
+        return -1;
+    } else if (cfg_set_find(&set, "help")) {
+        cfg_set_usage(&set, stdout);
+        cfg_set_free(&set);
+        return 0;
+    } else {
+        res = inner_do_ra(&set);
     }
-    return inner_do_ra(iface_name, src_mac, dst_mac, tgt_mac, src_addr,
-                       dst_addr, tgt_addr, prefix, repeat, timeout);
+
+    cfg_set_free(&set);
+
+    return res;
 }

--- a/src/ra.c
+++ b/src/ra.c
@@ -37,20 +37,23 @@
 #include <cfg.h>
 #include <utils.h>
 
-
 static struct cfg_parser parsers[] = {
     {'h', "help", CFG_BOOL, "print helpful usage information"},
-    {'i', "interface", CFG_STRING, "network interface that will be used to send packets"},
+    {'i', "interface", CFG_STRING,
+     "network interface that will be used to send packets"},
     {'s', "src-mac", CFG_HW_ADDRESS, "source address for the ethernet frame"},
-    {'d', "dst-mac", CFG_HW_ADDRESS, "destination address for the ethernet frame"},
+    {'d', "dst-mac", CFG_HW_ADDRESS,
+     "destination address for the ethernet frame"},
     {'S', "src-ip", CFG_IPV6_ADDRESS, "source ipv6 address in IPv6 header"},
-    {'D', "dst-ip", CFG_IPV6_ADDRESS, "destination ipv6 address in IPv6 header"},
-    {'t', "target-mac", CFG_HW_ADDRESS, "link layer address used for the target address "
-                                        "option of the advertisement"},
+    {'D', "dst-ip", CFG_IPV6_ADDRESS,
+     "destination ipv6 address in IPv6 header"},
+    {'t', "target-mac", CFG_HW_ADDRESS,
+     "link layer address used for the target address "
+     "option of the advertisement"},
     {'R', "router-ip", CFG_IPV6_ADDRESS, "ipv6 address of the router to spoof"},
     {'r', "repeat", CFG_INT, "send the packet <num> times"},
-    {'z', "timeout", CFG_INT, "wait <seconds> before sending the packet agein"}
-};
+    {'z', "timeout", CFG_INT,
+     "wait <seconds> before sending the packet agein"}};
 static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
 int inner_do_ra(const struct cfg_set* set) {
@@ -58,15 +61,11 @@ int inner_do_ra(const struct cfg_set* set) {
     enum sylkie_error err = SYLKIE_INVALID_ERR;
     struct sylkie_sender* sender = NULL;
     struct sylkie_packet* pkt = NULL;
-    static const u_int8_t all_nodes_eth[] = {
-        0x33, 0x33, 0x00, 0x00, 0x00, 0x01
-    };
+    static const u_int8_t all_nodes_eth[] = {0x33, 0x33, 0x00,
+                                             0x00, 0x00, 0x01};
     static struct in6_addr all_nodes_ip = {
-        .s6_addr = {
-            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
-        }
-    };
+        .s6_addr = {0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
     char* iface_name = NULL;
     const u_int8_t* dst_mac = NULL;
     const u_int8_t* src_mac = NULL;
@@ -75,7 +74,7 @@ int inner_do_ra(const struct cfg_set* set) {
     struct in6_addr* router_addr = NULL;
     struct in6_addr* src_addr = NULL;
 
-    if(cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
+    if (cfg_set_find_type(set, "interface", CFG_STRING, &iface_name)) {
         fprintf(stderr, "Must provide an interface to use.\n");
         cfg_set_usage(set, stderr);
         _exit(-1);
@@ -179,10 +178,10 @@ pid_t ra_json(struct json_object* jobj) {
     pid_t pid = -1;
     struct cfg_set set = {
         .usage = "sylkie ra [OPTIONS]",
-        .summary = "Send ICMPv6 Router Advertisement messages to the given address",
+        .summary =
+            "Send ICMPv6 Router Advertisement messages to the given address",
         .parsers = parsers,
-        .parsers_sz = parsers_sz
-    };
+        .parsers_sz = parsers_sz};
 
     res = cfg_set_init_json(&set, jobj);
 
@@ -190,7 +189,8 @@ pid_t ra_json(struct json_object* jobj) {
         fprintf(stderr, "Failed to initialize parsers\n");
         return -1;
     } else if (cfg_set_find(&set, "help")) {
-        fprintf(stderr, "\"help\" is an invalid option for running sylkie from json\n");
+        fprintf(stderr,
+                "\"help\" is an invalid option for running sylkie from json\n");
         cfg_set_free(&set);
         return -1;
     }
@@ -216,10 +216,10 @@ int ra_cmdline(int argc, const char** argv) {
     int res = -1;
     struct cfg_set set = {
         .usage = "sylkie ra [OPTIONS]",
-        .summary = "Send ICMPv6 Router Advertisement messages to the given address",
+        .summary =
+            "Send ICMPv6 Router Advertisement messages to the given address",
         .parsers = parsers,
-        .parsers_sz = parsers_sz
-    };
+        .parsers_sz = parsers_sz};
 
     if (argc < 1) {
         fprintf(stderr, "Too few arguments\n");
@@ -237,6 +237,7 @@ int ra_cmdline(int argc, const char** argv) {
         cfg_set_free(&set);
         return 0;
     } else {
+        lockdown();
         res = inner_do_ra(&set);
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -66,7 +66,7 @@ u_int8_t hex_char_to_byte(char ch) {
     }
 }
 
-int parse_hwaddr(const char* arg, u_int8_t addr[ETH_ALEN]) {
+int parse_hwaddr(const char* arg, u_int8_t* addr) {
     int len = strlen(arg);
     int i = 0, j = 0;
     u_int8_t tmp = 0;

--- a/tests/test_cfg_set.cpp
+++ b/tests/test_cfg_set.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-#include <sylkie_config.h>
 #include <cfg.h>
+#include <sylkie_config.h>
 }
 
 static struct cfg_parser parsers[] = {
@@ -13,80 +13,69 @@ static struct cfg_parser parsers[] = {
     {'z', "baz", CFG_STRING, "lesser known foobar"},
     {'q', "qux", CFG_HW_ADDRESS, "much lesser known than foobar"},
     {'e', "example", CFG_IPV6_ADDRESS, "random example"},
-    {'!', "never-called", CFG_BOOL, "this is never called"}
-};
+    {'!', "never-called", CFG_BOOL, "this is never called"}};
 
 static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
 static const char* parser_names[] = {
-    "verbosity",
-    "qux",
-    "foo",
-    "example",
-    "bool",
-    "baz",
-    "bar",
+    "verbosity", "qux", "foo", "example", "bool", "baz", "bar",
 };
 static size_t parser_names_sz = sizeof(parser_names) / sizeof(const char*);
 
-static const char* argv[] = {
-    "-v",
-    "42",
-    "--bool",
-    "-z",
-    "thisisastring",
-    "--example=ff02::1",
-    "--foo",
-    "255",
-    "-b",
-    "512",
-    "-q",
-    "00:00:00:00:00:00"
-};
+static const char* argv[] = {"-v",
+                             "42",
+                             "--bool",
+                             "-z",
+                             "thisisastring",
+                             "--example=ff02::1",
+                             "--foo",
+                             "255",
+                             "-b",
+                             "512",
+                             "-q",
+                             "00:00:00:00:00:00"};
 static int argc = sizeof(argv) / sizeof(const char*);
 
-static u_int8_t all_nodes[] = {
-    0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
-};
+static u_int8_t all_nodes[] = {0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
-static u_int8_t lo_mac[] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
+static u_int8_t lo_mac[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 #ifdef BUILD_JSON
 
 #endif
 
 class Cfg : public ::testing::Test {
-    public:
-        static char usage[];
-        static char summary[];
-    protected:
-        struct cfg_set config_set;
+  public:
+    static char usage[];
+    static char summary[];
+
+  protected:
+    struct cfg_set config_set;
 #ifdef BUILD_JSON
-        struct json_object* jobj;
+    struct json_object* jobj;
 #endif
 
-        virtual void SetUp() {
-            config_set.usage = usage;
-            config_set.summary = summary;
-            config_set.parsers = parsers;
-            config_set.parsers_sz = parsers_sz;
+    virtual void SetUp() {
+        config_set.usage = usage;
+        config_set.summary = summary;
+        config_set.parsers = parsers;
+        config_set.parsers_sz = parsers_sz;
 #ifdef BUILD_JSON
-            jobj = get_json_object();
+        jobj = get_json_object();
 #endif
-        }
+    }
 
-        virtual void TearDown() {
-            cfg_set_free(&config_set);
+    virtual void TearDown() {
+        cfg_set_free(&config_set);
 #ifdef BUILD_JSON
-            json_object_put(jobj);
+        json_object_put(jobj);
 #endif
-        }
+    }
 
 #ifdef BUILD_JSON
-        static struct json_object* get_json_object(void) {
-            static char json_input[] = "{ \
+    static struct json_object* get_json_object(void) {
+        static char json_input[] = "{ \
                             \"verbosity\": 42, \
                             \"bool\": true, \
                             \"baz\": \
@@ -96,123 +85,132 @@ class Cfg : public ::testing::Test {
                             \"bar\": 512, \
                             \"qux\": \"00:00:00:00:00:00\" \
                             }";
-            enum json_tokener_error jerr;
-            struct json_object* jobj = NULL;
-            struct json_tokener* tok = json_tokener_new();
+        enum json_tokener_error jerr;
+        struct json_object* jobj = NULL;
+        struct json_tokener* tok = json_tokener_new();
 
-            do {
-                jobj = json_tokener_parse_ex(tok, json_input, sizeof(json_input));
-                jerr = json_tokener_get_error(tok);
-            } while (jerr == json_tokener_continue);
+        do {
+            jobj = json_tokener_parse_ex(tok, json_input, sizeof(json_input));
+            jerr = json_tokener_get_error(tok);
+        } while (jerr == json_tokener_continue);
 
-            json_tokener_free(tok);
+        json_tokener_free(tok);
 
-            return jobj;
-        }
+        return jobj;
+    }
 #endif
 
-        void test_order() {
-            size_t i;
-            // Note: never-called should not be in this list
-            for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
-                EXPECT_EQ(strcmp(parser_names[i], config_set.options.map[i]->name), 0);
-            }
+    void test_order() {
+        size_t i;
+        // Note: never-called should not be in this list
+        for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+            EXPECT_EQ(strcmp(parser_names[i], config_set.options.map[i]->name),
+                      0);
+        }
+    }
+
+    void test_basic_find() {
+        size_t i;
+        const struct cfg_set_item* item = NULL;
+        // Ensure that each item expected can be found and returns an item
+        for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+            item = cfg_set_find(&config_set, parser_names[i]);
+            ASSERT_TRUE(item);
+            ASSERT_EQ(strcmp(item->name, parser_names[i]), 0);
         }
 
-        void test_basic_find() {
-            size_t i;
-            const struct cfg_set_item* item = NULL;
-            // Ensure that each item expected can be found and returns an item
-            for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
-                item = cfg_set_find(&config_set, parser_names[i]);
-                ASSERT_TRUE(item);
-                ASSERT_EQ(strcmp(item->name, parser_names[i]), 0);
-            }
+        // Ensure never-called cannot be found
+        item = cfg_set_find(&config_set, "never-called");
+        ASSERT_FALSE(item);
+    }
 
-            // Ensure never-called cannot be found
-            item = cfg_set_find(&config_set, "never-called");
-            ASSERT_FALSE(item);
-        }
+    void test_find() {
+        const struct cfg_set_item* item = NULL;
+        // Ensure each item returns the correct info with cfg_find_type
+        item = cfg_set_find(&config_set, "verbosity");
+        EXPECT_EQ(strcmp("verbosity", item->name), 0);
+        EXPECT_EQ(CFG_INT, item->value.type);
+        EXPECT_EQ(item->value.integer, 42);
 
-        void test_find() {
-            const struct cfg_set_item* item = NULL;
-            // Ensure each item returns the correct info with cfg_find_type
-            item = cfg_set_find(&config_set, "verbosity");
-            EXPECT_EQ(strcmp("verbosity", item->name), 0);
-            EXPECT_EQ(CFG_INT, item->value.type);
-            EXPECT_EQ(item->value.integer, 42);
+        item = cfg_set_find(&config_set, "bool");
+        EXPECT_EQ(strcmp("bool", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_BOOL);
+        EXPECT_EQ(item->value.boolean, true);
 
-            item = cfg_set_find(&config_set, "bool");
-            EXPECT_EQ(strcmp("bool", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_BOOL);
-            EXPECT_EQ(item->value.boolean, true);
+        item = cfg_set_find(&config_set, "baz");
+        EXPECT_EQ(strcmp("baz", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_STRING);
+        EXPECT_EQ(strcmp((const char*)item->value.data, "thisisastring"), 0);
 
-            item = cfg_set_find(&config_set, "baz");
-            EXPECT_EQ(strcmp("baz", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_STRING);
-            EXPECT_EQ(strcmp((const char*)item->value.data, "thisisastring"), 0);
+        item = cfg_set_find(&config_set, "example");
+        EXPECT_EQ(strcmp("example", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_IPV6_ADDRESS);
+        EXPECT_EQ(memcmp(item->value.data, &all_nodes, sizeof(all_nodes)), 0);
 
-            item = cfg_set_find(&config_set, "example");
-            EXPECT_EQ(strcmp("example", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_IPV6_ADDRESS);
-            EXPECT_EQ(memcmp(item->value.data, &all_nodes, sizeof(all_nodes)), 0);
+        item = cfg_set_find(&config_set, "foo");
+        EXPECT_EQ(strcmp("foo", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_BYTE);
+        EXPECT_EQ(item->value.byte, 255);
 
-            item = cfg_set_find(&config_set, "foo");
-            EXPECT_EQ(strcmp("foo", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_BYTE);
-            EXPECT_EQ(item->value.byte, 255);
+        item = cfg_set_find(&config_set, "bar");
+        EXPECT_EQ(strcmp("bar", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_WORD);
+        EXPECT_EQ(item->value.word, 512);
 
-            item = cfg_set_find(&config_set, "bar");
-            EXPECT_EQ(strcmp("bar", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_WORD);
-            EXPECT_EQ(item->value.word, 512);
+        item = cfg_set_find(&config_set, "qux");
+        EXPECT_EQ(strcmp("qux", item->name), 0);
+        EXPECT_EQ(item->value.type, CFG_HW_ADDRESS);
+        EXPECT_EQ(memcmp(item->value.data, &lo_mac, sizeof(lo_mac)), 0);
+    }
 
-            item =cfg_set_find(&config_set, "qux");
-            EXPECT_EQ(strcmp("qux", item->name), 0);
-            EXPECT_EQ(item->value.type, CFG_HW_ADDRESS);
-            EXPECT_EQ(memcmp(item->value.data, &lo_mac, sizeof(lo_mac)), 0);
-        }
+    void test_find_type() {
+        int integer = 0;
+        u_int16_t word = 0;
+        u_int8_t byte = 0;
+        void* data = NULL;
+        bool value = false;
 
-        void test_find_type() {
-            int integer = 0;
-            u_int16_t word = 0;
-            u_int8_t byte = 0;
-            void* data = NULL;
-            bool value = false;
+        // Ensure that unused arguments return -1
+        ASSERT_EQ(
+            cfg_set_find_type(&config_set, "never-called", CFG_BOOL, &value),
+            -1);
+        // Ensure find_type does not mutate the initial value
+        EXPECT_FALSE(value);
 
-            // Ensure that unused arguments return -1
-            ASSERT_EQ(cfg_set_find_type(&config_set, "never-called", CFG_BOOL, &value), -1);
-            // Ensure find_type does not mutate the initial value
-            EXPECT_FALSE(value);
+        // Ensure that when the wrong type is provided no data is returned
+        ASSERT_EQ(
+            cfg_set_find_type(&config_set, "verbosity", CFG_STRING, &integer),
+            -1);
+        //// The above call should not have mutated integer
+        EXPECT_EQ(integer, 0);
 
-            // Ensure that when the wrong type is provided no data is returned
-            ASSERT_EQ(cfg_set_find_type(&config_set, "verbosity", CFG_STRING, &integer), -1);
-            //// The above call should not have mutated integer
-            EXPECT_EQ(integer, 0);
+        // Ensure each item returns the correct info via cfg_set_find_type
 
-            // Ensure each item returns the correct info via cfg_set_find_type
+        ASSERT_EQ(
+            cfg_set_find_type(&config_set, "verbosity", CFG_INT, &integer), 0);
+        EXPECT_EQ(integer, 42);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "verbosity", CFG_INT, &integer), 0);
-            EXPECT_EQ(integer, 42);
+        ASSERT_EQ(cfg_set_find_type(&config_set, "bool", CFG_BOOL, &value), 0);
+        EXPECT_TRUE(value);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "bool", CFG_BOOL, &value), 0);
-            EXPECT_TRUE(value);
+        ASSERT_EQ(cfg_set_find_type(&config_set, "baz", CFG_STRING, &data), 0);
+        EXPECT_EQ(strcmp((const char*)data, "thisisastring"), 0);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "baz", CFG_STRING, &data), 0);
-            EXPECT_EQ(strcmp((const char*)data, "thisisastring"), 0);
+        ASSERT_EQ(
+            cfg_set_find_type(&config_set, "example", CFG_IPV6_ADDRESS, &data),
+            0);
+        EXPECT_EQ(memcmp(data, &all_nodes, sizeof(all_nodes)), 0);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "example", CFG_IPV6_ADDRESS, &data), 0);
-            EXPECT_EQ(memcmp(data, &all_nodes, sizeof(all_nodes)), 0);
+        ASSERT_EQ(cfg_set_find_type(&config_set, "foo", CFG_BYTE, &byte), 0);
+        EXPECT_EQ(byte, 255);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "foo", CFG_BYTE, &byte), 0);
-            EXPECT_EQ(byte, 255);
+        ASSERT_EQ(cfg_set_find_type(&config_set, "bar", CFG_WORD, &word), 0);
+        EXPECT_EQ(word, 512);
 
-            ASSERT_EQ(cfg_set_find_type(&config_set, "bar", CFG_WORD, &word), 0);
-            EXPECT_EQ(word, 512);
-
-            ASSERT_EQ(cfg_set_find_type(&config_set, "qux", CFG_HW_ADDRESS, &data), 0);
-            EXPECT_EQ(memcmp(data, &lo_mac, sizeof(lo_mac)), 0);
-        }
+        ASSERT_EQ(cfg_set_find_type(&config_set, "qux", CFG_HW_ADDRESS, &data),
+                  0);
+        EXPECT_EQ(memcmp(data, &lo_mac, sizeof(lo_mac)), 0);
+    }
 };
 
 char Cfg::usage[] = "Usage: This is a test parser";

--- a/tests/test_cfg_set.cpp
+++ b/tests/test_cfg_set.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 extern "C" {
+#include <sylkie_config.h>
 #include <cfg.h>
 }
 
@@ -44,39 +45,227 @@ static const char* argv[] = {
 };
 static int argc = sizeof(argv) / sizeof(const char*);
 
-TEST(cfg, order) {
-    size_t i;
-    struct cfg_set set = {
-        .usage="Simple Test Usage",
-        .summary="Test for usage printer"
-    };
-    cfg_set_init_cmdline(&set, parsers, parsers_sz, argc, argv);
-    for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
-        EXPECT_EQ(parser_names[i], set.options.map[i]->name);
-    }
-    cfg_set_free(&set);
+static u_int8_t all_nodes[] = {
+    0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+};
+
+static u_int8_t lo_mac[] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+#ifdef BUILD_JSON
+
+#endif
+
+class Cfg : public ::testing::Test {
+    public:
+        static char usage[];
+        static char summary[];
+    protected:
+        struct cfg_set config_set;
+#ifdef BUILD_JSON
+        struct json_object* jobj;
+#endif
+
+        virtual void SetUp() {
+            config_set.usage = usage;
+            config_set.summary = summary;
+            config_set.parsers = parsers;
+            config_set.parsers_sz = parsers_sz;
+#ifdef BUILD_JSON
+            jobj = get_json_object();
+#endif
+        }
+
+        virtual void TearDown() {
+            cfg_set_free(&config_set);
+#ifdef BUILD_JSON
+            json_object_put(jobj);
+#endif
+        }
+
+#ifdef BUILD_JSON
+        static struct json_object* get_json_object(void) {
+            static char json_input[] = "{ \
+                            \"verbosity\": 42, \
+                            \"bool\": true, \
+                            \"baz\": \
+                            \"thisisastring\", \
+                            \"example\": \"ff02::1\", \
+                            \"foo\": 255, \
+                            \"bar\": 512, \
+                            \"qux\": \"00:00:00:00:00:00\" \
+                            }";
+            enum json_tokener_error jerr;
+            struct json_object* jobj = NULL;
+            struct json_tokener* tok = json_tokener_new();
+
+            do {
+                jobj = json_tokener_parse_ex(tok, json_input, sizeof(json_input));
+                jerr = json_tokener_get_error(tok);
+            } while (jerr == json_tokener_continue);
+
+            json_tokener_free(tok);
+
+            return jobj;
+        }
+#endif
+
+        void test_order() {
+            size_t i;
+            // Note: never-called should not be in this list
+            for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+                EXPECT_EQ(strcmp(parser_names[i], config_set.options.map[i]->name), 0);
+            }
+        }
+
+        void test_basic_find() {
+            size_t i;
+            const struct cfg_set_item* item = NULL;
+            // Ensure that each item expected can be found and returns an item
+            for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+                item = cfg_set_find(&config_set, parser_names[i]);
+                ASSERT_TRUE(item);
+                ASSERT_EQ(strcmp(item->name, parser_names[i]), 0);
+            }
+
+            // Ensure never-called cannot be found
+            item = cfg_set_find(&config_set, "never-called");
+            ASSERT_FALSE(item);
+        }
+
+        void test_find() {
+            const struct cfg_set_item* item = NULL;
+            // Ensure each item returns the correct info with cfg_find_type
+            item = cfg_set_find(&config_set, "verbosity");
+            EXPECT_EQ(strcmp("verbosity", item->name), 0);
+            EXPECT_EQ(CFG_INT, item->value.type);
+            EXPECT_EQ(item->value.integer, 42);
+
+            item = cfg_set_find(&config_set, "bool");
+            EXPECT_EQ(strcmp("bool", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_BOOL);
+            EXPECT_EQ(item->value.boolean, true);
+
+            item = cfg_set_find(&config_set, "baz");
+            EXPECT_EQ(strcmp("baz", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_STRING);
+            EXPECT_EQ(strcmp((const char*)item->value.data, "thisisastring"), 0);
+
+            item = cfg_set_find(&config_set, "example");
+            EXPECT_EQ(strcmp("example", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_IPV6_ADDRESS);
+            EXPECT_EQ(memcmp(item->value.data, &all_nodes, sizeof(all_nodes)), 0);
+
+            item = cfg_set_find(&config_set, "foo");
+            EXPECT_EQ(strcmp("foo", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_BYTE);
+            EXPECT_EQ(item->value.byte, 255);
+
+            item = cfg_set_find(&config_set, "bar");
+            EXPECT_EQ(strcmp("bar", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_WORD);
+            EXPECT_EQ(item->value.word, 512);
+
+            item =cfg_set_find(&config_set, "qux");
+            EXPECT_EQ(strcmp("qux", item->name), 0);
+            EXPECT_EQ(item->value.type, CFG_HW_ADDRESS);
+            EXPECT_EQ(memcmp(item->value.data, &lo_mac, sizeof(lo_mac)), 0);
+        }
+
+        void test_find_type() {
+            int integer = 0;
+            u_int16_t word = 0;
+            u_int8_t byte = 0;
+            void* data = NULL;
+            bool value = false;
+
+            // Ensure that unused arguments return -1
+            ASSERT_EQ(cfg_set_find_type(&config_set, "never-called", CFG_BOOL, &value), -1);
+            // Ensure find_type does not mutate the initial value
+            EXPECT_FALSE(value);
+
+            // Ensure that when the wrong type is provided no data is returned
+            ASSERT_EQ(cfg_set_find_type(&config_set, "verbosity", CFG_STRING, &integer), -1);
+            //// The above call should not have mutated integer
+            EXPECT_EQ(integer, 0);
+
+            // Ensure each item returns the correct info via cfg_set_find_type
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "verbosity", CFG_INT, &integer), 0);
+            EXPECT_EQ(integer, 42);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "bool", CFG_BOOL, &value), 0);
+            EXPECT_TRUE(value);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "baz", CFG_STRING, &data), 0);
+            EXPECT_EQ(strcmp((const char*)data, "thisisastring"), 0);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "example", CFG_IPV6_ADDRESS, &data), 0);
+            EXPECT_EQ(memcmp(data, &all_nodes, sizeof(all_nodes)), 0);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "foo", CFG_BYTE, &byte), 0);
+            EXPECT_EQ(byte, 255);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "bar", CFG_WORD, &word), 0);
+            EXPECT_EQ(word, 512);
+
+            ASSERT_EQ(cfg_set_find_type(&config_set, "qux", CFG_HW_ADDRESS, &data), 0);
+            EXPECT_EQ(memcmp(data, &lo_mac, sizeof(lo_mac)), 0);
+        }
+};
+
+char Cfg::usage[] = "Usage: This is a test parser";
+char Cfg::summary[] = "Summary of a unit test";
+
+TEST_F(Cfg, cmdline_order) {
+    cfg_set_init_cmdline(&config_set, argc, argv);
+
+    test_order();
 }
 
-TEST(cfg, get) {
-    size_t i = 0;
-    int res = 0;
-    bool value = false, previous_value = false;
-    struct cfg_set config_set = {
-        .usage="executable [OPTIONS]",
-        .summary="Test for usage printer",
-    };
-    const struct cfg_set_item* item;
-    cfg_set_init_cmdline(&config_set, parsers, parsers_sz, argc, argv);
-    for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
-        item = cfg_set_find(&config_set, parser_names[i]);
-        ASSERT_TRUE(item);
-        ASSERT_EQ(item->name, parser_names[i]);
-    }
-    item = cfg_set_find(&config_set, "never-called");
-    ASSERT_FALSE(item);
-    previous_value = value;
-    res = cfg_set_find_type(&config_set, "never-called", CFG_BOOL, &value);
-    ASSERT_EQ(res, -1);
-    ASSERT_EQ(previous_value, value);
-    cfg_set_free(&config_set);
+TEST_F(Cfg, cmdline_basic_find) {
+    cfg_set_init_cmdline(&config_set, argc, argv);
+
+    test_basic_find();
 }
+
+TEST_F(Cfg, cmdline_find) {
+    cfg_set_init_cmdline(&config_set, argc, argv);
+
+    test_find();
+}
+
+TEST_F(Cfg, cmdline_find_type) {
+    cfg_set_init_cmdline(&config_set, argc, argv);
+
+    test_find_type();
+}
+
+#ifdef BUILD_JSON
+
+TEST_F(Cfg, json_order) {
+    cfg_set_init_json(&config_set, jobj);
+
+    test_order();
+}
+
+TEST_F(Cfg, json_basic_find) {
+    cfg_set_init_json(&config_set, jobj);
+
+    test_basic_find();
+}
+
+TEST_F(Cfg, json_find) {
+    cfg_set_init_json(&config_set, jobj);
+
+    test_find();
+}
+
+TEST_F(Cfg, json_find_type) {
+    cfg_set_init_json(&config_set, jobj);
+
+    test_find_type();
+}
+
+#endif

--- a/tests/test_cfg_set.cpp
+++ b/tests/test_cfg_set.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include <cfg.h>
+}
+
+static struct cfg_parser parsers[] = {
+    {'v', "verbosity", CFG_INT, "control the amound of logging"},
+    {'b', "bar", CFG_WORD, "random word"},
+    {'f', "foo", CFG_BYTE, "what would this be without foo"},
+    {'o', "bool", CFG_BOOL, "throw a random bool in the middle"},
+    {'z', "baz", CFG_STRING, "lesser known foobar"},
+    {'q', "qux", CFG_HW_ADDRESS, "much lesser known than foobar"},
+    {'e', "example", CFG_IPV6_ADDRESS, "random example"},
+    {'!', "never-called", CFG_BOOL, "this is never called"}
+};
+
+static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
+
+static const char* parser_names[] = {
+    "verbosity",
+    "qux",
+    "foo",
+    "example",
+    "bool",
+    "baz",
+    "bar",
+};
+static size_t parser_names_sz = sizeof(parser_names) / sizeof(const char*);
+
+static const char* argv[] = {
+    "-v",
+    "42",
+    "--bool",
+    "-z",
+    "thisisastring",
+    "--example=ff02::1",
+    "--foo",
+    "255",
+    "-b",
+    "512",
+    "-q",
+    "00:00:00:00:00:00"
+};
+static int argc = sizeof(argv) / sizeof(const char*);
+
+TEST(cfg, order) {
+    size_t i;
+    struct cfg_set set = {
+        .usage="Simple Test Usage",
+        .summary="Test for usage printer"
+    };
+    cfg_set_init_cmdline(&set, parsers, parsers_sz, argc, argv);
+    for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+        EXPECT_EQ(parser_names[i], set.options.map[i]->name);
+    }
+    cfg_set_free(&set);
+}
+
+TEST(cfg, get) {
+    size_t i = 0;
+    int res = 0;
+    bool value = false, previous_value = false;
+    struct cfg_set config_set = {
+        .usage="executable [OPTIONS]",
+        .summary="Test for usage printer",
+    };
+    const struct cfg_set_item* item;
+    cfg_set_init_cmdline(&config_set, parsers, parsers_sz, argc, argv);
+    for (i = 0; i < parsers_sz && i < parser_names_sz; ++i) {
+        item = cfg_set_find(&config_set, parser_names[i]);
+        ASSERT_TRUE(item);
+        ASSERT_EQ(item->name, parser_names[i]);
+    }
+    item = cfg_set_find(&config_set, "never-called");
+    ASSERT_FALSE(item);
+    previous_value = value;
+    res = cfg_set_find_type(&config_set, "never-called", CFG_BOOL, &value);
+    ASSERT_EQ(res, -1);
+    ASSERT_EQ(previous_value, value);
+    cfg_set_free(&config_set);
+}


### PR DESCRIPTION
A custom argument parsing framework might be a bit overboard, but parsing argv and json manually in each subcommand was a bit painful and was limiting to adding more options. In theory we could use something like getopt, but this way we're able to set up a config and use it for both json and command line input parsing.

Resolves: #10