### PR TITLE
Fix double free and parsing bug

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -607,6 +607,9 @@ static int cfg_set_parse_short(struct cfg_map* map,
                 }
             }
             item = NULL;
+        } else {
+            fprintf(stderr, "ERROR: Unknown argument %c\n", arg[i]);
+            return -1;
         }
     }
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -264,7 +264,7 @@ int main(int argc, const char** argv) {
         if (retval) {
             fprintf(stderr, "Failed to parse user input\n");
             cfg_set_usage(&set, stderr);
-            retval = -1;
+            return -1;
         } else {
 
             pid_buf = pid_buf_init(10);


### PR DESCRIPTION
 - Don't cause double free when passing bad input to main
 - Return an error when a bad short argument is given