### PR TITLE
Forgot to port prefix

### DIFF
--- a/src/ra.c
+++ b/src/ra.c
@@ -51,6 +51,7 @@ static struct cfg_parser parsers[] = {
      "link layer address used for the target address "
      "option of the advertisement"},
     {'R', "router-ip", CFG_IPV6_ADDRESS, "ipv6 address of the router to spoof"},
+    {'p', "prefix", CFG_INT, "send the packet <num> times"},
     {'r', "repeat", CFG_INT, "send the packet <num> times"},
     {'z', "timeout", CFG_INT,
      "wait <seconds> before sending the packet agein"}};


### PR DESCRIPTION
Ugh... Forgot to port the prefix argument to the `ra` command