### PR TITLE
Fix parse_hwaddr and leak in read_file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -155,11 +155,13 @@ struct sylkie_buffer* read_file(const char* arg) {
     }
     if ((fd = open(arg, O_RDONLY)) < 0) {
         fprintf(stderr, "%s cannot be opened\n", arg);
+        sylkie_buffer_free(buf);
         return NULL;
     }
     while ((res = read(fd, tmp_buffer, 1024)) != 0) {
         if (res < 0) {
             fprintf(stderr, "Failed to read from file %s\n", arg);
+            sylkie_buffer_free(buf);
             return NULL;
         }
         sylkie_buffer_add(buf, tmp_buffer, res);

--- a/tests/test_parsing.cpp
+++ b/tests/test_parsing.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include <utils.h>
+}
+
+TEST(parsing, parse_hwaddr) {
+    u_int8_t eth[6];
+    int res = parse_hwaddr("52:54:00:11:bf:3c", eth);
+    ASSERT_EQ(res, 0);
+    ASSERT_EQ(eth[0], 0x52);
+    ASSERT_EQ(eth[1], 0x54);
+    ASSERT_EQ(eth[2], 0x00);
+    ASSERT_EQ(eth[3], 0x11);
+    ASSERT_EQ(eth[4], 0xbf);
+    ASSERT_EQ(eth[5], 0x3c);
+}


### PR DESCRIPTION
- Correctly parse mac addr
- Do not leak memory when a file does not exist