### PR TITLE
Add lifetime parameter to the ra command

### DIFF
--- a/include/config.in
+++ b/include/config.in
@@ -18,6 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+/*! \mainpage sylkie index page
+ *
+ * \section intro_sec Introduction
+ *
+ * This is the inner workings of the <a href="http://sylkie.io">sylkie</a>
+ * command line tool.
+ *
+ * \section purpose_sec Purpose
+ *
+ * The documentation here is targeted at developers that are either
+ * contributing to the tool, or are looking to do something more complex.
+ * Most use cases can be covered by command line programs, but sometimes it
+ * is necessary to directly use the shared lib.
+ *
+ * \defgroup libsylkie Core public functions and structures
+ * \defgroup sylkie Private structures and functions used by main
+ */
+
 #define SYLKIE_VERSION "@PROJECT_VERSION@-@BUILD_OS@"
 #define SYLKIE_MAJOR_VERSION @PROJECT_VERSION_MAJOR@
 #define SYLKIE_MINOR_VERSION @PROJECT_VERSION_MINOR@

--- a/include/nd.h
+++ b/include/nd.h
@@ -30,24 +30,6 @@
 #include "proto_list.h"
 #include "sender.h"
 
-/*! \mainpage sylkie index page
- *
- * \section intro_sec Introduction
- *
- * This is the inner workings of the <a href="http://sylkie.io">sylkie</a>
- * command line tool.
- *
- * \section purpose_sec Purpose
- *
- * The documentation here is targeted at developers that are either
- * contributing to the tool, or are looking to do something more complex.
- * Most use cases can be covered by command line programs, but sometimes it
- * is necessary to directly use the shared lib.
- *
- * \defgroup libsylkie Core public functions and structures
- * \defgroup sylkie Private structures and functions used by main
- */
-
 struct sylkie_packet* sylkie_neighbor_advert_create(
     const u_int8_t eth_src[ETH_ALEN], const u_int8_t eth_dst[ETH_ALEN],
     struct in6_addr* ip_src, struct in6_addr* ip_dst, struct in6_addr* tgt_ip,
@@ -56,7 +38,8 @@ struct sylkie_packet* sylkie_neighbor_advert_create(
 struct sylkie_packet* sylkie_router_advert_create(
     const u_int8_t eth_src[ETH_ALEN], const u_int8_t eth_dst[ETH_ALEN],
     struct in6_addr* ip_src, struct in6_addr* ip_dst, struct in6_addr* tgt_ip,
-    u_int8_t prefix, const u_int8_t tgt_hw[ETH_ALEN], enum sylkie_error* err);
+    u_int8_t prefix, u_int16_t lifetime, const u_int8_t tgt_hw[ETH_ALEN],
+    enum sylkie_error* err);
 
 enum sylkie_error sylkie_icmpv6_to_buffer(struct sylkie_buffer* buf,
                                           const struct sylkie_packet* pkt,

--- a/src/ra.c
+++ b/src/ra.c
@@ -53,8 +53,8 @@ static struct cfg_parser parsers[] = {
     {'R', "router-ip", CFG_IPV6_ADDRESS, "ipv6 address of the router to spoof"},
     {'p', "prefix", CFG_INT, "send the packet <num> times"},
     {'r', "repeat", CFG_INT, "send the packet <num> times"},
-    {'z', "timeout", CFG_INT,
-     "wait <seconds> before sending the packet agein"}};
+    {'l', "lifetime", CFG_WORD, "valid and preferred lifetime of router"},
+    {'z', "timeout", CFG_INT, "wait <n> seconds before sending agein"}};
 static size_t parsers_sz = sizeof(parsers) / sizeof(struct cfg_parser);
 
 int inner_do_ra(const struct cfg_set* set) {
@@ -71,6 +71,7 @@ int inner_do_ra(const struct cfg_set* set) {
     const u_int8_t* dst_mac = NULL;
     const u_int8_t* src_mac = NULL;
     const u_int8_t* tgt_mac = NULL;
+    u_int16_t lifetime = 0;
     struct in6_addr* dst_addr = NULL;
     struct in6_addr* router_addr = NULL;
     struct in6_addr* src_addr = NULL;
@@ -85,6 +86,7 @@ int inner_do_ra(const struct cfg_set* set) {
     cfg_set_find_type(set, "dst-ip", CFG_IPV6_ADDRESS, &dst_addr);
     cfg_set_find_type(set, "src-ip", CFG_IPV6_ADDRESS, &src_addr);
     cfg_set_find_type(set, "router-ip", CFG_IPV6_ADDRESS, &router_addr);
+    cfg_set_find_type(set, "lifetime", CFG_WORD, &lifetime);
 
     if (!dst_mac && !dst_addr) {
         dst_mac = all_nodes_eth;
@@ -120,7 +122,8 @@ int inner_do_ra(const struct cfg_set* set) {
     }
 
     pkt = sylkie_router_advert_create(src_mac, dst_mac, src_addr, dst_addr,
-                                      router_addr, prefix, tgt_mac, &err);
+                                      router_addr, prefix, lifetime, tgt_mac,
+                                      &err);
 
     if (!pkt) {
         fprintf(stderr, "%s\n", "Could not allocate packet");


### PR DESCRIPTION
# tl;dr
 
 - Add the lifetime option to the ra command
 - Add an additional option to internal functions
 - Ensure that the hop limit is set to 0xff
 - Move doxygen mainpage to `sylkie_config.h` - Not sure if this is the best location but ¯\\_(ツ)_/¯

# Become the default route

Given the following.

```
{
    "router-advert": [
        {
            "interface": "ens3",
            "target-mac": "52:54:00:11:bf:3c",
            "router-ip": "fe80::61ad:fda3:3032:f6f4",
            "prefix": 64,
            "repeat": -1,
            "timeout": 5
        },
        {
            "interface": "ens3",
            "target-mac": "52:54:00:c2:a7:7c",
            "router-ip": "fe80::cbed:6822:cd23:bbdb",
            "prefix": 64,
            "lifetime": 600,
            "repeat": -1,
            "timeout": 5
        }
    ]
}
```

If `fe80::61ad:fda3:3032:f6f4` were the default route, all nodes on the link-local scope would remove it as the default route, and add `fe80::cbed:6822:cd23:bbdb` as the default route.