### PR TITLE
Finish adding docs to all of the structures

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -45,7 +45,7 @@ struct sylkie_buffer {
  * \memberof sylkie_buffer
  *
  * \brief Initialize a sylkie_buffer to size `sz`
- * \param sz size of the buffer to be created
+ * \param sz Size of the buffer to be created
  *
  * Note: A size of zero will not allocate any memory. No memory
  * will be allocated untill the first add function is used in
@@ -60,9 +60,9 @@ struct sylkie_buffer* sylkie_buffer_init(size_t sz);
  * \memberof sylkie_buffer
  *
  * \brief Append data to the buffer
- * \param buf buffer structure to which the data will be added
- * \param ptr pointer to the data to be added
- * \param sz size of the data pointer
+ * \param buf Buffer structure to which the data will be added
+ * \param ptr Pointer to the data to be added
+ * \param sz Size of the data pointer
  */
 int sylkie_buffer_add(struct sylkie_buffer* buf, const void* ptr, size_t sz);
 
@@ -70,9 +70,9 @@ int sylkie_buffer_add(struct sylkie_buffer* buf, const void* ptr, size_t sz);
  * \memberof sylkie_buffer
  *
  * \brief Apend data to the buffer
- * \param buf buffer structure to which the data will be added
- * \param value value to be repeated
- * \param sz number of times to repeat the value in the buffer
+ * \param buf Buffer structure to which the data will be added
+ * \param value Value to be repeated
+ * \param sz Number of times to repeat the value in the buffer
  */
 int sylkie_buffer_add_value(struct sylkie_buffer* buf, const u_int8_t value,
                             size_t sz);
@@ -81,7 +81,7 @@ int sylkie_buffer_add_value(struct sylkie_buffer* buf, const u_int8_t value,
  * \memberof sylkie_buffer
  *
  * \brief Copy the given buffer
- * \param buf buffer that will be cloned
+ * \param buf Buffer that will be cloned
  */
 struct sylkie_buffer* sylkie_buffer_clone(const struct sylkie_buffer* buf);
 
@@ -89,7 +89,7 @@ struct sylkie_buffer* sylkie_buffer_clone(const struct sylkie_buffer* buf);
  * \memberof sylkie_buffer
  *
  * \brief Print the contents of the buffer in hexadecimal to stdout
- * \param buf buffer to be printed
+ * \param buf Buffer to be printed
  */
 void sylkie_buffer_print(const struct sylkie_buffer* buf);
 
@@ -97,7 +97,7 @@ void sylkie_buffer_print(const struct sylkie_buffer* buf);
  * \memberof sylkie_buffer
  *
  * \brief Free the memory allocated to this buffer
- * \param buf buffer to be freed
+ * \param buf Buffer to be freed
  */
 void sylkie_buffer_free(struct sylkie_buffer* buf);
 

--- a/include/config.in
+++ b/include/config.in
@@ -31,6 +31,41 @@
  * contributing to the tool, or are looking to do something more complex.
  * Most use cases can be covered by command line programs, but sometimes it
  * is necessary to directly use the shared lib.
+
+ * \section get_started Getting Started
+ *
+ * \subsection get_code Get the code
+ * ```
+ * git clone https://github.com/dlrobertson/sylkie
+ * cd ./sylkie
+ *
+ * # Compile the code
+ * mkdir -p ./build
+ * cd ./build
+ * cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON ..
+ * make
+ * make install
+ * ```
+ *
+ * \subsection run_tests Run the tests
+ *
+ * Ensure that you ran cmake with the additional argument `-DBUILD_TESTS=ON`.
+ *
+ * ```
+ * make test
+ * ```
+ *
+ * or
+ *
+ * ```
+ * ./sylkie_test
+ * ```
+ *
+ * \subsection build_docs Build the docs
+ *
+ * Ensure that you ran cmake with the additional argument `-DBUILD_DOCS=ON`,
+ * and make sure `doxygen` is installed on your local system. If everything
+ * has been set up correctly `make doc` should compile the documentation.
  *
  * \defgroup libsylkie Core public functions and structures
  * \defgroup sylkie Private structures and functions used by main

--- a/include/nd.h
+++ b/include/nd.h
@@ -30,19 +30,68 @@
 #include "proto_list.h"
 #include "sender.h"
 
+/**
+ * \defgroup sylkie_nd NDP packet creation helpers
+ * \ingroup libsylkie
+ * @{
+ */
+
+/**
+ * \brief Create a sylkie_packet containing a Neighbor Advertisement
+ * \param eth_src Source ethernet address
+ * \param eth_dst Destination ethernet address
+ * \param ip_src Source IPv6 address
+ * \param ip_dst Destination IPv6 address
+ * \param tgt_ip Target IPv6 address (address to be spoofed)
+ * \param tgt_tw Hardware address to be the new value in the neighbor cache
+ * \param err Pointer to sylkie_error
+ *
+ * @see sylkie_packet
+ */
 struct sylkie_packet* sylkie_neighbor_advert_create(
     const u_int8_t eth_src[ETH_ALEN], const u_int8_t eth_dst[ETH_ALEN],
     struct in6_addr* ip_src, struct in6_addr* ip_dst, struct in6_addr* tgt_ip,
     const u_int8_t tgt_hw[ETH_ALEN], enum sylkie_error* err);
 
+/**
+ * \brief Create a sylkie_packet containing a Router Advertisement
+ * \param eth_src Source ethernet address
+ * \param eth_dst Destination ethernet address
+ * \param ip_src Source IPv6 address
+ * \param ip_dst Destination IPv6 address
+ * \param tgt_ip Target IPv6 address (address to be spoofed)
+ * \param prefix Link prefix
+ * \param lifetime Lifetime parameter for the router
+ * \param tgt_tw Hardware address to be the new value in the neighbor cache
+ * \param err Pointer to sylkie_error
+ *
+ * NB: When the lifetime parameter is set to 0 the router indicated
+ * by tgt_ip will be removed from the targetted hosts list of default
+ * route. If the lifetime is >0, the router indicated by tgt_ip will
+ * be added or updated in the targetted hosts list of default routes.
+ *
+ * @see sylkie_packet
+ */
 struct sylkie_packet* sylkie_router_advert_create(
     const u_int8_t eth_src[ETH_ALEN], const u_int8_t eth_dst[ETH_ALEN],
     struct in6_addr* ip_src, struct in6_addr* ip_dst, struct in6_addr* tgt_ip,
     u_int8_t prefix, u_int16_t lifetime, const u_int8_t tgt_hw[ETH_ALEN],
     enum sylkie_error* err);
 
+/**
+ * \brief Convert the sylkie_packet into a sylkie_buffer
+ * \param buf Destination buffer the packet bytes will be added to
+ * \param node Souce node of a sylkie_proto_node
+ *
+ * NB: This function is used by sylkie_packet to ensure the icmpv6
+ * checksum is correctly set. In a future version this will be
+ * a private function.
+ *
+ * @see sylkie_packet
+ */
 enum sylkie_error sylkie_icmpv6_to_buffer(struct sylkie_buffer* buf,
-                                          const struct sylkie_packet* pkt,
                                           const struct sylkie_proto_node* node);
+
+/// @} end of doxygen sylkie_nd group
 
 #endif

--- a/include/packet.h
+++ b/include/packet.h
@@ -53,9 +53,9 @@ struct sylkie_packet* sylkie_packet_init();
  * \memberof sylkie_packet
  *
  * \brief Add a protocol header to the packet
- * \param type The type of the protocol header added
- * \param data The header data to be added
- * \param sz The size of the header data
+ * \param type Type of the protocol header added
+ * \param data Header data to be added
+ * \param sz Size of the header data
  */
 enum sylkie_error sylkie_packet_add(struct sylkie_packet* pkt,
                                     enum sylkie_proto_type type, void* data,

--- a/include/proto_list.h
+++ b/include/proto_list.h
@@ -25,6 +25,15 @@
 
 #include "errors.h"
 
+/**
+ * \defgroup protocol protocol list structures and methods
+ * \ingroup libsylkie
+ * @{
+ */
+
+/**
+ * \brief Enumerated list of supported protocols
+ */
 enum sylkie_proto_type {
     SYLKIE_ETH = 0,
     SYLKIE_IPv6,
@@ -33,46 +42,131 @@ enum sylkie_proto_type {
     SYLKIE_INVALID_HDR_TYPE,
 };
 
+/**
+ * \brief Generic structure used to define a protocol header
+ */
 struct sylkie_proto {
+    /// Type of the protocol header
     enum sylkie_proto_type type;
+    /// Raw bytes
     void* data;
+    /// length of the associated data
     size_t len;
 };
 
+/**
+ * \brief Node of the protocol header linked list
+ */
 struct sylkie_proto_node {
+    /// The protocol header for the given node
     struct sylkie_proto hdr;
+    /// The next node in the list of protocol headers
     struct sylkie_proto_node* next;
+    /// The next previous node in the list of protocol headers
     struct sylkie_proto_node* prev;
 };
 
-struct sylkie_proto_list {
-    struct sylkie_proto_node* head;
-    struct sylkie_proto_node* tail;
-};
+/**
+ * \brief List of protocol header nodes that form a packet
+ */
+struct sylkie_proto_list;
 
+/**
+ * \memberof sylkie_proto
+ *
+ * \brief Initialize a sylkie_proto
+ * \param hdr Pointer to the proto to initialize
+ * \param type Protocol type of the header
+ * \param data Raw data contained in the header
+ * \param len Length of the raw data
+ */
 int sylkie_proto_init(struct sylkie_proto* hdr, enum sylkie_proto_type type,
                       void* data, size_t len);
 
+/**
+ * \memberof sylkie_proto_node
+ *
+ * \brief Free allocated resources associated with a given node
+ */
 void sylkie_proto_node_free(struct sylkie_proto_node* node);
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Initialize a sylkie_proto_list
+ */
 struct sylkie_proto_list* sylkie_proto_list_init();
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Add a protocol header to the given list
+ * \param lst Protocol list to add headers to
+ * \param type Protocol header type
+ * \param data Raw header data
+ * \param len Length of the raw header data
+ */
 enum sylkie_error sylkie_proto_list_add(struct sylkie_proto_list* lst,
                                         enum sylkie_proto_type type, void* data,
                                         size_t len);
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Add a sylkie_proto_node to a given protocol list
+ * \param lst Protocol list to add the node to
+ * \param node Protocol header list node to add to the list
+ */
 enum sylkie_error sylkie_proto_list_add_node(struct sylkie_proto_list* lst,
                                              struct sylkie_proto_node* node);
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Remove a sylkie_proto_node from a given protocol list
+ * \param lst Protocol header list to remove the node from
+ * \param node Pointer to the protocol header list node to remove
+ */
 enum sylkie_error sylkie_proto_list_rm_node(struct sylkie_proto_list* lst,
                                             struct sylkie_proto_node* node);
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Remove all protocol nodes from a given list of the given type
+ * \param lst Protocol header list to remove the nodes from
+ * \param type Type of protocol nodes to remove
+ */
 enum sylkie_error sylkie_proto_list_rm(struct sylkie_proto_list* lst,
                                        enum sylkie_proto_type type);
 
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Return the head of a given protocol list
+ * \param lst Protocol header list to return the head of
+ */
+struct sylkie_proto_node* sylkie_proto_list_head(struct sylkie_proto_list* lst);
+
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Return the tail of a given protocol list
+ * \param lst Protocol header list to return the tail of
+ */
+struct sylkie_proto_node* sylkie_proto_list_tail(struct sylkie_proto_list* lst);
+
+/**
+ * \memberof sylkie_proto_list
+ *
+ * \brief Free all allocated resources associated with the list
+ * \param lst Protocol header list to deallocate
+ */
 void sylkie_proto_list_free(struct sylkie_proto_list* lst);
 
 #define SYLKIE_HEADER_LIST_FOREACH(lst, node)                                  \
-    for (node = lst->head; node; node = node->next)
+    for (node = sylkie_proto_list_head(lst); node; node = node->next)
+
+/// @} end of doxygen protocol group
 
 #endif

--- a/include/sender.h
+++ b/include/sender.h
@@ -30,28 +30,92 @@
 #include "errors.h"
 #include "packet.h"
 
-struct sylkie_sender {
-    int fd;
-    int mtu;
-    struct sockaddr_ll addr;
-};
+/**
+ * \defgroup sender sylkie_sender structures and methods
+ * \ingroup libsylkie
+ * @{
+ */
 
+/**
+ * \brief Generic structure used to send packets
+ *
+ * NB: sylkie_sender make heavy use of raw sockets.
+ */
+struct sylkie_sender;
+
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Initialize a sender for a given interface
+ * \param iface Name of the interface to be used
+ * \param err Pointer to sylkie_error to be set on error
+ */
 struct sylkie_sender* sylkie_sender_init(const char* iface,
                                          enum sylkie_error* err);
 
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Send a sylkie_buffer
+ * \param sender sylkie_sender to be used to send the buffer
+ * \param buf sylkie_buffer to be sent
+ * \param flags Flags to be set on send
+ * \param err Pointer to sylkie_error to be set on error
+ */
 int sylkie_sender_send_buffer(struct sylkie_sender* sender,
                               const struct sylkie_buffer* buf, int flags,
                               enum sylkie_error* err);
 
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Send a sylkie_packet
+ * \param sender sylkie_sender to be used to send the packet
+ * \param pkt sylkie_packet to be sent
+ * \param flags Flags to be set on send
+ * \param err Pointer to sylkie_error to be set on error
+ */
 int sylkie_sender_send_packet(struct sylkie_sender* sender,
                               struct sylkie_packet* pkt, int flags,
                               enum sylkie_error* err);
 
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Send raw data given a the length of the data
+ * \param sender sylkie_sender to be used to send the data
+ * \param data Raw data to be sent
+ * \param len Size of the raw data to be sent
+ * \param flags Flags to be set on send
+ * \param err Pointer to sylkie_error to be set on error
+ */
 int sylkie_sender_send(struct sylkie_sender* sender, const u_int8_t* data,
                        size_t len, int flags, enum sylkie_error* err);
 
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Return the link address associated with a given sender
+ * \param sender sylkie_sender to return the address for
+ */
+const u_int8_t* sylkie_sender_addr(struct sylkie_sender* sender);
+
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Deallocate all associated resources
+ * \param sender sylkie_sender to be deallocated
+ */
 void sylkie_sender_free(struct sylkie_sender* sender);
 
+/**
+ * \memberof sylkie_sender
+ *
+ * \brief Pretty print the metadata associated with the sender
+ * \param sender sylkie_sender to print
+ */
 void sylkie_print_sender(struct sylkie_sender* sender, FILE* output);
+
+/// @} end of doxygen sender group
 
 #endif

--- a/lib/nd.c
+++ b/lib/nd.c
@@ -231,7 +231,6 @@ static void icmp_set_checksum(const struct sylkie_proto_node* node) {
 
 enum sylkie_error
 sylkie_icmpv6_to_buffer(struct sylkie_buffer* buf,
-                        const struct sylkie_packet* pkt,
                         const struct sylkie_proto_node* node) {
     if (node) {
         icmp_set_checksum(node);

--- a/lib/packet.c
+++ b/lib/packet.c
@@ -38,7 +38,6 @@ struct sylkie_packet {
 
 static enum sylkie_error
 sylkie_generic_to_buffer(struct sylkie_buffer* buf,
-                         const struct sylkie_packet* pkt,
                          const struct sylkie_proto_node* node) {
     if (node && !sylkie_buffer_add(buf, node->hdr.data, node->hdr.len)) {
         return SYLKIE_SUCCESS;
@@ -50,7 +49,6 @@ sylkie_generic_to_buffer(struct sylkie_buffer* buf,
 static struct {
     enum sylkie_proto_type type;
     enum sylkie_error (*fn)(struct sylkie_buffer* buf,
-                            const struct sylkie_packet* pkt,
                             const struct sylkie_proto_node* node);
 } s_to_buffer_cmds[] = {
     {SYLKIE_ETH, sylkie_generic_to_buffer},
@@ -110,7 +108,7 @@ struct sylkie_buffer* sylkie_packet_to_buffer(struct sylkie_packet* pkt,
     SYLKIE_HEADER_LIST_FOREACH(pkt->lst, node) {
         if (node->hdr.type < SYLKIE_INVALID_HDR_TYPE &&
             s_to_buffer_cmds[node->hdr.type].fn) {
-            (s_to_buffer_cmds[node->hdr.type].fn)(buf, pkt, node);
+            (s_to_buffer_cmds[node->hdr.type].fn)(buf, node);
         }
     }
 

--- a/lib/proto_list.c
+++ b/lib/proto_list.c
@@ -24,6 +24,14 @@
 
 #include <proto_list.h>
 
+// Complete definition of a protocol list
+struct sylkie_proto_list {
+    // The first protocol header in the list
+    struct sylkie_proto_node* head;
+    // The last protocol header in the list
+    struct sylkie_proto_node* tail;
+};
+
 // sylkie_proto_node methods
 
 static void rm_proto_node(struct sylkie_proto_list* lst,
@@ -152,6 +160,16 @@ enum sylkie_error sylkie_proto_list_rm(struct sylkie_proto_list* lst,
         }
         return SYLKIE_NOT_FOUND;
     }
+}
+
+struct sylkie_proto_node*
+sylkie_proto_list_head(struct sylkie_proto_list* lst) {
+    return (lst) ? lst->head : NULL;
+}
+
+struct sylkie_proto_node*
+sylkie_proto_list_tail(struct sylkie_proto_list* lst) {
+    return (lst) ? lst->tail : NULL;
 }
 
 void sylkie_proto_list_free(struct sylkie_proto_list* lst) {

--- a/lib/sender.c
+++ b/lib/sender.c
@@ -35,6 +35,16 @@
 #include <packet.h>
 #include <sender.h>
 
+// Complete definition of sylkie_sender
+struct sylkie_sender {
+    // File descriptor of the socket to be used
+    int fd;
+    // MTU of the link
+    int mtu;
+    // Sockaddr of the device to be used
+    struct sockaddr_ll addr;
+};
+
 struct sylkie_sender* sylkie_sender_init(const char* iface,
                                          enum sylkie_error* err) {
     struct ifreq ifr;
@@ -159,4 +169,8 @@ void sylkie_sender_free(struct sylkie_sender* sender) {
         free(sender);
         sender = NULL;
     }
+}
+
+const u_int8_t* sylkie_sender_addr(struct sylkie_sender* sender) {
+    return (sender) ? sender->addr.sll_addr : NULL;
 }

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -303,11 +303,6 @@ static struct cfg_set_item* parse_mac_json(const struct cfg_parser* parser,
 }
 #endif
 
-// Boolean parsers
-//
-// NB: The command line version does not need a parser. The value is assumed by
-// the presence of the option.
-
 #ifdef BUILD_JSON
 static struct cfg_set_item* parse_bool_json(const struct cfg_parser* parser,
                                             struct json_object* jobj) {
@@ -570,8 +565,9 @@ static int cfg_set_parse_short(struct cfg_map* map,
             // We don't need to parse an argument for boolean options
             if (parser->type != CFG_BOOL) {
                 if (*next_consumed) {
-                    fprintf(stderr, "ERROR: Invalid combination \"-%s\". -%c"
-                                    "requires an argument\n",
+                    fprintf(stderr,
+                            "ERROR: Invalid combination \"-%s\". -%c"
+                            "requires an argument\n",
                             arg, arg[i]);
                     return -1;
                 } else if (!next) {

--- a/src/na.c
+++ b/src/na.c
@@ -119,7 +119,7 @@ int inner_do_na(const struct cfg_set* set) {
     }
 
     if (cfg_set_find_type(set, "src-mac", CFG_HW_ADDRESS, &src_mac)) {
-        src_mac = sender->addr.sll_addr;
+        src_mac = sylkie_sender_addr(sender);
     }
 
     if (cfg_set_find_type(set, "target-mac", CFG_HW_ADDRESS, &tgt_mac)) {

--- a/src/ra.c
+++ b/src/ra.c
@@ -136,7 +136,7 @@ int inner_do_ra(const struct cfg_set* set) {
     }
 
     if (cfg_set_find_type(set, "src-mac", CFG_HW_ADDRESS, &src_mac)) {
-        src_mac = sender->addr.sll_addr;
+        src_mac = sylkie_sender_addr(sender);
     }
 
     if (cfg_set_find_type(set, "target-mac", CFG_HW_ADDRESS, &tgt_mac)) {


### PR DESCRIPTION
 - Add docs to the last remaining structures
   - Add docs to proto_list, sender, and NDP helpers
   - Add more info to the main doc page
   - Fix discovered errors in documentation
 - Fix other discovered errors
   - Some struct members had no need to be public
   - Remove unneeded argument to packet to buffer functions